### PR TITLE
Don't update DEPROVISIONED users.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -11,7 +11,7 @@ provider:
     subnetIds: ${file(${env:ECS_CONFIG}/bin/vars.yml):us-east-1.prod_apps_1_all}
   stackTags:
     Name: ${env:PROJECT_NAME}-${self:custom.environmentMap.${env:ENVIRONMENT}}
-    owner: apps@cru.org
+    owner: devops-engineering-team@cru.org
     application: ${env:PROJECT_NAME}
     env: ${self:custom.environmentMap.${env:ENVIRONMENT}}
     managed_by: serverless-framework
@@ -37,6 +37,7 @@ provider:
   environment: ${file(serverless/environment.js)}
 
 package:
+  individually: true
   exclude:
     - .serverless/**
     - .webpack/**

--- a/sns/user/lifecycle/status-change.test.js
+++ b/sns/user/lifecycle/status-change.test.js
@@ -33,7 +33,7 @@ describe('status change handler', () => {
       await handler(deactivateEvent)
       expect(mockGetUser).toHaveBeenCalledWith('00uo1red47olcenOx0h7')
       expect(mockDeleteProfile).toHaveBeenCalledWith({})
-      expect(mockUpdate).toHaveBeenCalled()
+      expect(mockUpdate).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
Fixes https://rollbar.com/Cru/okta-hooks/items/9/
Code was attempting to remove the GR attributes which produced a 404 Not Found in Okta for DEPROVISIONED users.