### PR TITLE
Sync okta profile to Global Registry on create

### DIFF
--- a/models/global-registry.js
+++ b/models/global-registry.js
@@ -22,6 +22,7 @@ class GlobalRegistry {
     await this.deleteDesignationRelationshipIfNecessary(profile)
 
     const result = await this.client.Entity.post({ [PERSON_ENTITY_TYPE]: personEntity }, {
+      full_response: true,
       require_mdm: true,
       fields: 'master_person:relationship'
     })

--- a/serverless.yml
+++ b/serverless.yml
@@ -207,7 +207,7 @@ functions:
     handler: sns/user/lifecycle/create.handler
     description: Handle all `user.lifecycle.create` okta events
     memorySize: 256
-    timeout: 6
+    timeout: 30
     events:
       - sns:
           arn: !Ref OktaEventsSNSTopic

--- a/sns/user/lifecycle/create.js
+++ b/sns/user/lifecycle/create.js
@@ -2,16 +2,19 @@ import { Client } from '@okta/okta-sdk-nodejs'
 import OktaEvent from '../../../models/okta-event'
 import rollbar from '../../../config/rollbar'
 import GUID from '../../../models/guid'
+import GlobalRegistry from '../../../models/global-registry'
 
 export const handler = async (lambdaEvent) => {
   const okta = new Client()
+  const globalRegistry = new GlobalRegistry(process.env.GLOBAL_REGISTRY_TOKEN, process.env.GLOBAL_REGISTRY_URL)
   try {
     const request = new OktaEvent(lambdaEvent.Records[0].Sns.Message)
     const user = await okta.getUser(request.userId)
     if (typeof user.profile.theKeyGuid === 'undefined') {
       user.profile.theKeyGuid = GUID.create()
-      await user.update()
     }
+    await globalRegistry.createOrUpdateProfile(user.profile)
+    await user.update()
   } catch (error) {
     await rollbar.error('user.lifecycle.create Error', error, { lambdaEvent })
     throw error


### PR DESCRIPTION
This updates the `userLifecycleCreate` lambda to also sync the Okta profile to Global Registry.

This fixes an issue where users created by the TheKey were never synced to Global Registry. When the okta-hooks lambdas were initially written, the TheKey creation code was triggering a `profile-update` which is not longer happening due to the LDAP syncing. This stopped new users from being sent to Global Registry.