### PR TITLE
New spreadsheet contains duplicates. DynamoDB doesn't like duplicates.

### DIFF
--- a/models/restricted-domains.js
+++ b/models/restricted-domains.js
@@ -7,6 +7,7 @@ import has from 'lodash/has'
 import difference from 'lodash/difference'
 import concat from 'lodash/concat'
 import chunk from 'lodash/chunk'
+import uniq from 'lodash/uniq'
 
 class RestrictedDomains {
   static async isRestricted (emailAddress) {
@@ -43,7 +44,7 @@ class RestrictedDomains {
     if (typeof response.data.values === 'undefined') {
       throw new Error('Restricted Domains Google sheet returned empty response.')
     }
-    return compact(response.data.values.map(item => toLower(item[0])))
+    return uniq(compact(response.data.values.map(item => toLower(item[0]))))
   }
 
   async syncDomainsFromGoogle () {

--- a/models/restricted-domains.test.js
+++ b/models/restricted-domains.test.js
@@ -67,7 +67,9 @@ describe('RestrictedDomains', () => {
           values: [
             ['cru.org'],
             ['Avengers.org'],
-            ['example.com']]
+            ['example.com'],
+            ['Cru.org'],
+            ['']]
         }
       })
       DocumentClient._scanPromiseMock.mockResolvedValue({


### PR DESCRIPTION
```json
{
  "errorType": "ValidationException",
  "errorMessage": "Provided list of item keys contains duplicates"
}
```