### PR TITLE
Add HCM linked identity to GR person entity

### DIFF
--- a/src/models/global-registry.ts
+++ b/src/models/global-registry.ts
@@ -7,6 +7,7 @@ export const PERSON_DESIGNATION_ENTITY_TYPE = 'person_person_designation_designa
 export const THE_KEY_SYSYEM = 'the_key'
 export const PSHR_SYSTEM = 'pshr'
 export const SIEBEL_SYSTEM = 'siebel'
+export const HCM_SYSTEM = 'hcm'
 
 interface OktaUserProfile {
   theKeyGuid: string
@@ -123,13 +124,16 @@ class GlobalRegistry {
       ...(profile.usEmployeeId && !this.isProbablyTestAccount(profile.login)
         ? {
             account_number: profile.usEmployeeId,
+            hcm_person_number: profile.usEmployeeId,
             linked_identities: {
+              [HCM_SYSTEM]: { hcm_person_number: profile.usEmployeeId },
               [PSHR_SYSTEM]: { account_number: profile.usEmployeeId },
               [SIEBEL_SYSTEM]: { account_number: profile.usEmployeeId }
             }
           }
         : {
-            account_number: null
+            account_number: null,
+            hcm_person_number: null
           }),
       ...(designationEntityId
         ? {

--- a/tests/models/global-registry.test.ts
+++ b/tests/models/global-registry.test.ts
@@ -175,6 +175,7 @@ describe('GlobalRegistry', () => {
             key_guid: profile.theKeyGuid
           },
           account_number: null,
+          hcm_person_number: null,
           'designation:relationship': {
             designation: designationEntityId,
             client_integration_id: profile.theKeyGuid
@@ -200,7 +201,9 @@ describe('GlobalRegistry', () => {
             key_guid: profile.theKeyGuid
           },
           account_number: '0987654',
+          hcm_person_number: '0987654',
           linked_identities: {
+            hcm: { hcm_person_number: '0987654' },
             pshr: { account_number: '0987654' },
             siebel: { account_number: '0987654' }
           }


### PR DESCRIPTION
## Summary
- Add `hcm` as a linked identity system, mapping `usEmployeeId` to `hcm_person_number`
- Add top-level `hcm_person_number` property alongside `account_number` on the person entity
- HCM linked identity appears first in the linked_identities object

## Test plan
- [x] Existing tests updated and passing
- [x] ~100% coverage maintained