### PR TITLE
Guard against deprovisioned users in create handler

### DIFF
--- a/src/handlers/sns/user-account-update-profile.ts
+++ b/src/handlers/sns/user-account-update-profile.ts
@@ -3,6 +3,7 @@ import { Client } from '@okta/okta-sdk-nodejs'
 import rollbar from '../../config/rollbar.js'
 import OktaEvent from '../../models/okta-event.js'
 import GlobalRegistry from '../../models/global-registry.js'
+import type { OktaUserProfile } from '../../types/okta.js'
 
 export const handler = async (lambdaEvent: SNSEvent): Promise<void> => {
   const okta = new Client({ cacheMiddleware: null })
@@ -12,7 +13,7 @@ export const handler = async (lambdaEvent: SNSEvent): Promise<void> => {
   )
   try {
     const request = new OktaEvent(lambdaEvent.Records[0].Sns.Message)
-    const user = await okta.userApi.getUser({ userId: request.userId! }) as any
+    const user = await okta.userApi.getUser({ userId: request.userId! })
     let hasUpdate = false
 
     // If login changed, and it doesn't match email, set email to the value of login and mark for update
@@ -32,7 +33,7 @@ export const handler = async (lambdaEvent: SNSEvent): Promise<void> => {
       request.changedAttributes.length > 0
     ) {
       console.log(`Updating profile: okta=${request.userId} gr=${user.profile?.thekeyGrPersonId}`)
-      if (await globalRegistry.createOrUpdateProfile(user.profile)) {
+      if (await globalRegistry.createOrUpdateProfile(user.profile as OktaUserProfile)) {
         hasUpdate = true
       }
     }

--- a/src/handlers/sns/user-lifecycle-create.ts
+++ b/src/handlers/sns/user-lifecycle-create.ts
@@ -14,6 +14,13 @@ export const handler = async (lambdaEvent: SNSEvent): Promise<void> => {
   try {
     const request = new OktaEvent(lambdaEvent.Records[0].Sns.Message)
     const user = await okta.userApi.getUser({ userId: request.userId! }) as any
+    if (user.status === 'DEPROVISIONED') {
+      await okta.groupApi.unassignUserFromGroup({
+        groupId: process.env.OKTA_MISSING_GROUP_ID!,
+        userId: request.userId!
+      })
+      return
+    }
     if (typeof user.profile?.theKeyGuid === 'undefined') {
       user.profile.theKeyGuid = GUID.create()
     }

--- a/src/handlers/sns/user-lifecycle-create.ts
+++ b/src/handlers/sns/user-lifecycle-create.ts
@@ -4,6 +4,7 @@ import OktaEvent from '../../models/okta-event.js'
 import rollbar from '../../config/rollbar.js'
 import GUID from '../../models/guid.js'
 import GlobalRegistry from '../../models/global-registry.js'
+import type { OktaUserProfile } from '../../types/okta.js'
 
 export const handler = async (lambdaEvent: SNSEvent): Promise<void> => {
   const okta = new Client({ cacheMiddleware: null })
@@ -13,18 +14,22 @@ export const handler = async (lambdaEvent: SNSEvent): Promise<void> => {
   )
   try {
     const request = new OktaEvent(lambdaEvent.Records[0].Sns.Message)
-    const user = await okta.userApi.getUser({ userId: request.userId! }) as any
+    const user = await okta.userApi.getUser({ userId: request.userId! })
     if (user.status === 'DEPROVISIONED') {
+      const missingGroupId = process.env.OKTA_MISSING_GROUP_ID
+      if (!missingGroupId) {
+        throw new Error('OKTA_MISSING_GROUP_ID is not set')
+      }
       await okta.groupApi.unassignUserFromGroup({
-        groupId: process.env.OKTA_MISSING_GROUP_ID!,
+        groupId: missingGroupId,
         userId: request.userId!
       })
       return
     }
     if (typeof user.profile?.theKeyGuid === 'undefined') {
-      user.profile.theKeyGuid = GUID.create()
+      user.profile!.theKeyGuid = GUID.create()
     }
-    await globalRegistry.createOrUpdateProfile(user.profile)
+    await globalRegistry.createOrUpdateProfile(user.profile as OktaUserProfile)
     await okta.userApi.updateUser({ userId: request.userId!, user })
   } catch (error) {
     await rollbar.error('user.lifecycle.create Error', error as Error, { lambdaEvent })

--- a/src/handlers/sns/user-lifecycle-status-change.ts
+++ b/src/handlers/sns/user-lifecycle-status-change.ts
@@ -3,6 +3,7 @@ import { Client } from '@okta/okta-sdk-nodejs'
 import OktaEvent from '../../models/okta-event.js'
 import rollbar from '../../config/rollbar.js'
 import GlobalRegistry from '../../models/global-registry.js'
+import type { OktaUserProfile } from '../../types/okta.js'
 
 export const handler = async (lambdaEvent: SNSEvent): Promise<void> => {
   const okta = new Client({ cacheMiddleware: null })
@@ -12,15 +13,15 @@ export const handler = async (lambdaEvent: SNSEvent): Promise<void> => {
   )
   try {
     const event = new OktaEvent(lambdaEvent.Records[0].Sns.Message)
-    const user = await okta.userApi.getUser({ userId: event.userId! }) as any
+    const user = await okta.userApi.getUser({ userId: event.userId! })
     switch (user.status) {
       case 'ACTIVE':
-        if (await globalRegistry.createOrUpdateProfile(user.profile)) {
+        if (await globalRegistry.createOrUpdateProfile(user.profile as OktaUserProfile)) {
           await okta.userApi.updateUser({ userId: event.userId!, user })
         }
         break
       case 'DEPROVISIONED':
-        await globalRegistry.deleteProfile(user.profile)
+        await globalRegistry.deleteProfile(user.profile as OktaUserProfile)
         break
     }
   } catch (error) {

--- a/src/models/global-registry.ts
+++ b/src/models/global-registry.ts
@@ -1,24 +1,13 @@
 import { GRClient } from 'global-registry-nodejs-client'
 import { endsWith, startsWith, get, find } from 'lodash'
 import equalsIgnoreCase from '../utils/equals-ignore-case.js'
+import type { OktaUserProfile } from '../types/okta.js'
 
 export const PERSON_ENTITY_TYPE = 'person'
 export const PERSON_DESIGNATION_ENTITY_TYPE = 'person_person_designation_designation'
 export const THE_KEY_SYSYEM = 'the_key'
 export const PSHR_SYSTEM = 'pshr'
 export const SIEBEL_SYSTEM = 'siebel'
-
-interface OktaUserProfile {
-  theKeyGuid: string
-  login: string
-  firstName: string
-  lastName: string
-  email?: string
-  usDesignationNumber?: string
-  usEmployeeId?: string
-  thekeyGrPersonId?: string | null
-  grMasterPersonId?: string | null
-}
 
 interface DesignationRelationshipEntity {
   id: string

--- a/src/types/okta.ts
+++ b/src/types/okta.ts
@@ -1,0 +1,20 @@
+import type { UserProfile } from '@okta/okta-sdk-nodejs'
+
+/**
+ * Okta user profile extended with the custom fields this project reads
+ * and writes. Custom fields live on Okta's `UserProfile` via its
+ * `[key: string]: CustomAttributeValue | ... | undefined` index signature;
+ * this interface narrows the types we rely on so downstream code can use
+ * them without per-site casts.
+ */
+export interface OktaUserProfile extends UserProfile {
+  theKeyGuid: string
+  login: string
+  firstName: string
+  lastName: string
+  email?: string
+  usDesignationNumber?: string
+  usEmployeeId?: string
+  thekeyGrPersonId?: string | null
+  grMasterPersonId?: string | null
+}

--- a/tests/handlers/sns/user-lifecycle-create.test.ts
+++ b/tests/handlers/sns/user-lifecycle-create.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { handler } from '@/handlers/sns/user-lifecycle-create.js'
 import rollbar from '@/config/rollbar.js'
 import { Client, mockGetUser, mockUpdateUser, mockUnassignUserFromGroup } from '../../mocks/okta-sdk-nodejs.js'
@@ -20,12 +20,13 @@ vi.mock('@okta/okta-sdk-nodejs', async () => {
 })
 
 describe('user.lifecycle.create SNS message', () => {
-  beforeAll(() => {
-    process.env.OKTA_MISSING_GROUP_ID = 'test-group-id'
-  })
-
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubEnv('OKTA_MISSING_GROUP_ID', 'test-group-id')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   it('does nothing if user already has `theKeyGuid`', async () => {
@@ -59,6 +60,14 @@ describe('user.lifecycle.create SNS message', () => {
     })
     expect(mockCreateOrUpdateProfile).not.toHaveBeenCalled()
     expect(mockUpdateUser).not.toHaveBeenCalled()
+  })
+
+  it('throws if OKTA_MISSING_GROUP_ID is not set when handling a deprovisioned user', async () => {
+    vi.stubEnv('OKTA_MISSING_GROUP_ID', '')
+    mockGetUser.mockResolvedValue({ status: 'DEPROVISIONED', profile: {} })
+    await expect(handler(created as any)).rejects.toThrow('OKTA_MISSING_GROUP_ID is not set')
+    expect(mockUnassignUserFromGroup).not.toHaveBeenCalled()
+    expect(rollbar.error).toHaveBeenCalled()
   })
 
   it('should return an error', async () => {

--- a/tests/handlers/sns/user-lifecycle-create.test.ts
+++ b/tests/handlers/sns/user-lifecycle-create.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import { handler } from '@/handlers/sns/user-lifecycle-create.js'
 import rollbar from '@/config/rollbar.js'
-import { Client, mockGetUser, mockUpdateUser } from '../../mocks/okta-sdk-nodejs.js'
+import { Client, mockGetUser, mockUpdateUser, mockUnassignUserFromGroup } from '../../mocks/okta-sdk-nodejs.js'
 import GUID from '@/models/guid.js'
 
 import created from '../../fixtures/sns/user-lifecycle-create.json'
@@ -16,10 +16,14 @@ vi.mock('@/models/global-registry.js', () => ({
 }))
 vi.mock('@okta/okta-sdk-nodejs', async () => {
   const mock = await import('../../mocks/okta-sdk-nodejs.js')
-  return { Client: mock.Client, mockGetUser: mock.mockGetUser }
+  return { Client: mock.Client, mockGetUser: mock.mockGetUser, mockUnassignUserFromGroup: mock.mockUnassignUserFromGroup }
 })
 
 describe('user.lifecycle.create SNS message', () => {
+  beforeAll(() => {
+    process.env.OKTA_MISSING_GROUP_ID = 'test-group-id'
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -27,7 +31,7 @@ describe('user.lifecycle.create SNS message', () => {
   it('does nothing if user already has `theKeyGuid`', async () => {
     const profile = { theKeyGuid: '58ae8a88-878c-47a8-a22e-543665b7fe33' }
     mockCreateOrUpdateProfile.mockResolvedValue(true)
-    mockGetUser.mockResolvedValue({ profile })
+    mockGetUser.mockResolvedValue({ status: 'ACTIVE', profile })
     await handler(created as any)
     expect(Client).toHaveBeenCalled()
     expect(mockGetUser).toHaveBeenCalledWith({ userId: '00uo1red47olcenOx0h7' })
@@ -39,11 +43,22 @@ describe('user.lifecycle.create SNS message', () => {
     vi.spyOn(GUID, 'create').mockReturnValue('58ae8a88-878c-47a8-a22e-543665b7fe33')
     mockCreateOrUpdateProfile.mockResolvedValue(true)
     const profile: Record<string, unknown> = {}
-    mockGetUser.mockResolvedValue({ profile })
+    mockGetUser.mockResolvedValue({ status: 'ACTIVE', profile })
     await handler(created as any)
     expect(profile.theKeyGuid).toEqual('58ae8a88-878c-47a8-a22e-543665b7fe33')
     expect(mockUpdateUser).toHaveBeenCalled()
     expect(mockCreateOrUpdateProfile).toHaveBeenCalledWith(profile)
+  })
+
+  it('removes deprovisioned user from missing group and skips processing', async () => {
+    mockGetUser.mockResolvedValue({ status: 'DEPROVISIONED', profile: {} })
+    await handler(created as any)
+    expect(mockUnassignUserFromGroup).toHaveBeenCalledWith({
+      groupId: 'test-group-id',
+      userId: '00uo1red47olcenOx0h7'
+    })
+    expect(mockCreateOrUpdateProfile).not.toHaveBeenCalled()
+    expect(mockUpdateUser).not.toHaveBeenCalled()
   })
 
   it('should return an error', async () => {

--- a/tests/mocks/okta-sdk-nodejs.ts
+++ b/tests/mocks/okta-sdk-nodejs.ts
@@ -18,6 +18,7 @@ export const setUsers = (users: MockUser[] = []) => {
 
 export const mockGetUser = vi.fn()
 export const mockUpdateUser = vi.fn()
+export const mockUnassignUserFromGroup = vi.fn()
 export const mockListGroupUsers = vi.fn(() => ({
   each: (fn: (user: MockUser) => boolean | void) => forEach(values.users, fn)
 }))
@@ -28,6 +29,7 @@ export const Client = vi.fn().mockImplementation(() => ({
     updateUser: mockUpdateUser
   },
   groupApi: {
-    listGroupUsers: mockListGroupUsers
+    listGroupUsers: mockListGroupUsers,
+    unassignUserFromGroup: mockUnassignUserFromGroup
   }
 }))


### PR DESCRIPTION
## Summary
- Skip GR profile creation and Okta profile update for deprovisioned users in the `user-lifecycle-create` handler
- Remove deprovisioned users from the missing group so they stop retrying every 30 minutes
- Addresses Error Type 3 (Okta 403 E0000038) from the [stage error analysis](https://docs.google.com/document/d/1QlU9DPA7vcngDc17Ydc4T22nl0dnjrfkquD0aLrlevg/edit)

## Test plan
- [x] New test: deprovisioned users are removed from missing group, GR and Okta update skipped
- [x] Existing tests updated with `status: 'ACTIVE'` to exercise the happy path
- [x] 100% coverage maintained