### PR TITLE
Persist theKeyGuid to Okta before calling Global Registry

### DIFF
--- a/src/handlers/sns/user-lifecycle-create.ts
+++ b/src/handlers/sns/user-lifecycle-create.ts
@@ -14,12 +14,16 @@ export const handler = async (lambdaEvent: SNSEvent): Promise<void> => {
   try {
     const request = new OktaEvent(lambdaEvent.Records[0].Sns.Message)
     const user = await okta.userApi.getUser({ userId: request.userId! }) as any
-    if (typeof user.profile?.theKeyGuid === 'undefined') {
+    if (typeof user.profile === 'undefined') {
+      throw new Error(`Okta user ${request.userId} has no profile`)
+    }
+    if (typeof user.profile.theKeyGuid === 'undefined') {
       user.profile.theKeyGuid = GUID.create()
       await okta.userApi.updateUser({ userId: request.userId!, user })
     }
-    await globalRegistry.createOrUpdateProfile(user.profile)
-    await okta.userApi.updateUser({ userId: request.userId!, user })
+    if (await globalRegistry.createOrUpdateProfile(user.profile)) {
+      await okta.userApi.updateUser({ userId: request.userId!, user })
+    }
   } catch (error) {
     await rollbar.error('user.lifecycle.create Error', error as Error, { lambdaEvent })
     throw error

--- a/src/handlers/sns/user-lifecycle-create.ts
+++ b/src/handlers/sns/user-lifecycle-create.ts
@@ -16,6 +16,7 @@ export const handler = async (lambdaEvent: SNSEvent): Promise<void> => {
     const user = await okta.userApi.getUser({ userId: request.userId! }) as any
     if (typeof user.profile?.theKeyGuid === 'undefined') {
       user.profile.theKeyGuid = GUID.create()
+      await okta.userApi.updateUser({ userId: request.userId!, user })
     }
     await globalRegistry.createOrUpdateProfile(user.profile)
     await okta.userApi.updateUser({ userId: request.userId!, user })

--- a/tests/handlers/sns/user-lifecycle-create.test.ts
+++ b/tests/handlers/sns/user-lifecycle-create.test.ts
@@ -35,6 +35,15 @@ describe('user.lifecycle.create SNS message', () => {
     expect(mockUpdateUser).toHaveBeenCalledTimes(1)
   })
 
+  it('skips Okta update when GR profile is unchanged', async () => {
+    const profile = { theKeyGuid: '58ae8a88-878c-47a8-a22e-543665b7fe33' }
+    mockCreateOrUpdateProfile.mockResolvedValue(false)
+    mockGetUser.mockResolvedValue({ profile })
+    await handler(created as any)
+    expect(mockCreateOrUpdateProfile).toHaveBeenCalledWith(profile)
+    expect(mockUpdateUser).not.toHaveBeenCalled()
+  })
+
   it('generates and persists theKeyGuid before calling GR', async () => {
     vi.spyOn(GUID, 'create').mockReturnValue('58ae8a88-878c-47a8-a22e-543665b7fe33')
     mockCreateOrUpdateProfile.mockResolvedValue(true)
@@ -57,6 +66,14 @@ describe('user.lifecycle.create SNS message', () => {
     expect(profile.theKeyGuid).toEqual('58ae8a88-878c-47a8-a22e-543665b7fe33')
     expect(mockUpdateUser).toHaveBeenCalledTimes(1)
     expect(mockUpdateUser).toHaveBeenCalledWith({ userId: '00uo1red47olcenOx0h7', user })
+  })
+
+  it('throws if Okta returns a user with no profile', async () => {
+    mockGetUser.mockResolvedValue({})
+    await expect(handler(created as any)).rejects.toThrow('Okta user 00uo1red47olcenOx0h7 has no profile')
+    expect(mockCreateOrUpdateProfile).not.toHaveBeenCalled()
+    expect(mockUpdateUser).not.toHaveBeenCalled()
+    expect(rollbar.error).toHaveBeenCalled()
   })
 
   it('should return an error', async () => {

--- a/tests/handlers/sns/user-lifecycle-create.test.ts
+++ b/tests/handlers/sns/user-lifecycle-create.test.ts
@@ -24,7 +24,7 @@ describe('user.lifecycle.create SNS message', () => {
     vi.clearAllMocks()
   })
 
-  it('does nothing if user already has `theKeyGuid`', async () => {
+  it('does not persist GUID if user already has `theKeyGuid`', async () => {
     const profile = { theKeyGuid: '58ae8a88-878c-47a8-a22e-543665b7fe33' }
     mockCreateOrUpdateProfile.mockResolvedValue(true)
     mockGetUser.mockResolvedValue({ profile })
@@ -32,18 +32,31 @@ describe('user.lifecycle.create SNS message', () => {
     expect(Client).toHaveBeenCalled()
     expect(mockGetUser).toHaveBeenCalledWith({ userId: '00uo1red47olcenOx0h7' })
     expect(mockCreateOrUpdateProfile).toHaveBeenCalledWith(profile)
-    expect(mockUpdateUser).toHaveBeenCalled()
+    expect(mockUpdateUser).toHaveBeenCalledTimes(1)
   })
 
-  it('updates user profile with new `theKeyGuid` if its missing', async () => {
+  it('generates and persists theKeyGuid before calling GR', async () => {
     vi.spyOn(GUID, 'create').mockReturnValue('58ae8a88-878c-47a8-a22e-543665b7fe33')
     mockCreateOrUpdateProfile.mockResolvedValue(true)
     const profile: Record<string, unknown> = {}
-    mockGetUser.mockResolvedValue({ profile })
+    const user = { profile }
+    mockGetUser.mockResolvedValue(user)
     await handler(created as any)
     expect(profile.theKeyGuid).toEqual('58ae8a88-878c-47a8-a22e-543665b7fe33')
-    expect(mockUpdateUser).toHaveBeenCalled()
+    expect(mockUpdateUser).toHaveBeenCalledTimes(2)
     expect(mockCreateOrUpdateProfile).toHaveBeenCalledWith(profile)
+  })
+
+  it('persists theKeyGuid even when GR call fails', async () => {
+    vi.spyOn(GUID, 'create').mockReturnValue('58ae8a88-878c-47a8-a22e-543665b7fe33')
+    mockCreateOrUpdateProfile.mockRejectedValue(new Error('GR failed'))
+    const profile: Record<string, unknown> = {}
+    const user = { profile }
+    mockGetUser.mockResolvedValue(user)
+    await expect(handler(created as any)).rejects.toThrow('GR failed')
+    expect(profile.theKeyGuid).toEqual('58ae8a88-878c-47a8-a22e-543665b7fe33')
+    expect(mockUpdateUser).toHaveBeenCalledTimes(1)
+    expect(mockUpdateUser).toHaveBeenCalledWith({ userId: '00uo1red47olcenOx0h7', user })
   })
 
   it('should return an error', async () => {


### PR DESCRIPTION
## Summary
- Save the generated theKeyGuid to the Okta profile immediately after creation, before the GR call
- Prevents GUID regeneration on retry when GR fails — every retry now uses the same `client_integration_id`
- Addresses the theKeyGuid regeneration bug described in the [stage error analysis](https://docs.google.com/document/d/1QlU9DPA7vcngDc17Ydc4T22nl0dnjrfkquD0aLrlevg/edit)

## Test plan
- [x] New test: theKeyGuid is persisted even when GR call fails
- [x] Updated test: `updateUser` called twice on happy path (GUID persistence + GR ID writeback)
- [x] Existing test: `updateUser` called once when GUID already exists
- [x] 100% coverage maintained