### PR TITLE
Resolve GR account_number / hcm_person_number collisions before saving the_key person entity

### DIFF
--- a/docs/superpowers/plans/2026-06-09-gr-account-number-collision.md
+++ b/docs/superpowers/plans/2026-06-09-gr-account-number-collision.md
@@ -1,0 +1,1103 @@
+# GR account_number Collision Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Before okta-hooks saves a new Cru-email staff account's `the_key` Global Registry person entity, release the same employee number from any stale `the_key` person entity (and from the stale Okta account) so the unique-constraint collision on `account_number`/`hcm_person_number` cannot block the save.
+
+**Architecture:** A new `resolveAccountNumberCollision(profile)` method on the `GlobalRegistry` model runs at the top of `createOrUpdateProfile`. It gates on (has employee id, not a test account, Cru-domain email, `orca !== false`), looks up conflicting `the_key` person entities by **both** identifier fields (transition-resilient), clears `account_number`+`hcm_person_number` on each conflict via `Entity.put` (required), and clears `usEmployeeId` on the stale Okta account via an injected Okta client (best-effort, Rollbar on failure).
+
+**Tech Stack:** TypeScript (ES modules), Vitest, `global-registry-nodejs-client`, `@okta/okta-sdk-nodejs`, lodash, Rollbar.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-gr-account-number-collision-design.md` (all four GR assumptions verified against stage / GR source).
+
+---
+
+## File Structure
+
+- `src/config/domains.ts` *(new)* — `googleManagedDomains` + `hasCruDomain()`, ported from us-onboarding. Single responsibility: Cru email-domain classification.
+- `tests/config/domains.test.ts` *(new)* — unit tests for `hasCruDomain`.
+- `src/types/okta.ts` *(modify)* — add `orca?: boolean`.
+- `src/types/global-registry-nodejs-client.d.ts` *(modify)* — expose `put`, add `fields` to get options.
+- `tests/mocks/global-registry-nodejs-client.ts` *(modify)* — add `mockEntityPUT`.
+- `tests/mocks/okta-sdk-nodejs.ts` *(modify)* — add `mockListUsers` to the Client surface.
+- `src/models/global-registry.ts` *(modify)* — constructor Okta param; `resolveAccountNumberCollision` + helpers; call it in `createOrUpdateProfile`.
+- `tests/models/global-registry.test.ts` *(modify)* — tests for the new behavior.
+- `src/handlers/sns/user-lifecycle-create.ts`, `user-lifecycle-status-change.ts`, `user-account-update-profile.ts` *(modify)* — pass the Okta client into `GlobalRegistry`.
+
+---
+
+## Task 1: Port `hasCruDomain` domain config
+
+**Files:**
+- Create: `src/config/domains.ts`
+- Test: `tests/config/domains.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/config/domains.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { hasCruDomain } from '@/config/domains.js'
+
+describe('hasCruDomain', () => {
+  it('returns true for Google-managed Cru domains (case-insensitive)', () => {
+    expect(hasCruDomain('jon.watson@cru.org')).toBe(true)
+    expect(hasCruDomain('someone@familylife.com')).toBe(true)
+    expect(hasCruDomain('SOMEONE@CRU.ORG')).toBe(true)
+  })
+
+  it('returns false for non-Cru domains', () => {
+    expect(hasCruDomain('person@gmail.com')).toBe(false)
+    expect(hasCruDomain('person@example.com')).toBe(false)
+  })
+
+  it('returns false for malformed input', () => {
+    expect(hasCruDomain('not-an-email')).toBe(false)
+    expect(hasCruDomain('')).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/config/domains.test.ts`
+Expected: FAIL — cannot resolve `@/config/domains.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/config/domains.ts`:
+
+```ts
+/**
+ * Cru email-domain classification.
+ *
+ * Ported from us-onboarding (src/config/domains.ts) and kept self-contained here to
+ * avoid a cross-repo dependency. If the canonical list changes there, update it here too.
+ */
+
+export const googleManagedDomains: string[] = [
+  'cru.org',
+  'allvox.com',
+  'arrowheadconferences.org',
+  'athletesinaction.org',
+  'bridgesinternational.com',
+  'cembassy.org',
+  'crumilitary.org',
+  'designmovement.org',
+  'destino.org',
+  'epicmovement.com',
+  'facultycommons.org',
+  'familylife.com',
+  'isponline.org',
+  'jesusfilm.org',
+  'sightlineministry.org',
+  'unto.com',
+  'campuscrusadeforchrist.com',
+  'ccci.org',
+  'cru.comm',
+  'crusade.org',
+  'keynote.org',
+  'studentventure.com'
+]
+
+/**
+ * True when the email's domain is one of Cru's Google-managed (work) domains.
+ */
+export function hasCruDomain(email: string): boolean {
+  const domain = email?.split('@')[1]?.toLowerCase()
+  return domain ? googleManagedDomains.includes(domain) : false
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/config/domains.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/domains.ts tests/config/domains.test.ts
+git commit -m "Add hasCruDomain domain config to okta-hooks"
+```
+
+---
+
+## Task 2: Types & mocks scaffolding
+
+No behavior yet — these support later tasks. Verified by `npm run typecheck`.
+
+**Files:**
+- Modify: `src/types/okta.ts`
+- Modify: `src/types/global-registry-nodejs-client.d.ts`
+- Modify: `tests/mocks/global-registry-nodejs-client.ts`
+- Modify: `tests/mocks/okta-sdk-nodejs.ts`
+
+- [ ] **Step 1: Add `orca` to the profile type**
+
+In `src/types/okta.ts`, add the field to the `OktaUserProfile` interface (after `lastName`):
+
+```ts
+  orca?: boolean
+```
+
+- [ ] **Step 2: Expose `put` and `fields` on the GR client type**
+
+Replace the body of `src/types/global-registry-nodejs-client.d.ts` `EntityGetOptions` and `EntityClient` with:
+
+```ts
+  interface EntityGetOptions {
+    entity_type: string
+    filters: Record<string, string | undefined>
+    fields?: string
+  }
+
+  interface EntityPostOptions {
+    full_response?: boolean
+    require_mdm?: boolean
+    fields?: string
+  }
+
+  interface EntityResponse {
+    entity?: Record<string, unknown>
+    entities?: Array<Record<string, unknown>>
+  }
+
+  interface EntityClient {
+    get(options: EntityGetOptions): Promise<EntityResponse>
+    post(entity: Record<string, unknown>, options?: EntityPostOptions): Promise<EntityResponse>
+    put(
+      id: string,
+      content: Record<string, unknown>,
+      options?: EntityPostOptions
+    ): Promise<EntityResponse>
+    delete(entityId: string): Promise<void>
+  }
+```
+
+- [ ] **Step 3: Add `mockEntityPUT` to the GR client mock**
+
+Replace `tests/mocks/global-registry-nodejs-client.ts` with:
+
+```ts
+import { vi } from 'vitest'
+
+export const mockEntityGET = vi.fn()
+export const mockEntityDELETE = vi.fn()
+export const mockEntityPOST = vi.fn()
+export const mockEntityPUT = vi.fn()
+
+export const GRClient = vi.fn().mockImplementation(() => ({
+  Entity: {
+    get: mockEntityGET,
+    delete: mockEntityDELETE,
+    post: mockEntityPOST,
+    put: mockEntityPUT
+  }
+}))
+```
+
+- [ ] **Step 4: Add `listUsers` to the Okta SDK mock**
+
+In `tests/mocks/okta-sdk-nodejs.ts`, add the export and wire it into `userApi`:
+
+Add after `export const mockUpdateUser = vi.fn()`:
+
+```ts
+export const mockListUsers = vi.fn()
+```
+
+And change the `userApi` block in the `Client` mock to:
+
+```ts
+  userApi: {
+    getUser: mockGetUser,
+    updateUser: mockUpdateUser,
+    listUsers: mockListUsers
+  },
+```
+
+- [ ] **Step 5: Verify type-check and existing tests still pass**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+Run: `npm run test`
+Expected: all existing tests PASS (no behavior changed yet).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/okta.ts src/types/global-registry-nodejs-client.d.ts tests/mocks/global-registry-nodejs-client.ts tests/mocks/okta-sdk-nodejs.ts
+git commit -m "Add orca type, GR put/fields types, and put/listUsers mocks"
+```
+
+---
+
+## Task 3: Inject optional Okta client into GlobalRegistry
+
+**Files:**
+- Modify: `src/models/global-registry.ts`
+- Test: `tests/models/global-registry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/models/global-registry.test.ts`, add a test inside the existing `describe('constructor()', ...)` block:
+
+```ts
+    it('accepts an optional Okta client', () => {
+      const okta = { userApi: {} } as any
+      const gr = new GlobalRegistry('token', 'https://example.com', okta)
+      expect(gr).toBeInstanceOf(GlobalRegistry)
+    })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: FAIL — TypeScript error: Expected 2 arguments, but got 3.
+
+- [ ] **Step 3: Add the constructor parameter and imports**
+
+In `src/models/global-registry.ts`, add imports near the top (after the existing lodash import):
+
+```ts
+import type { Client, User } from '@okta/okta-sdk-nodejs'
+import rollbar from '../config/rollbar.js'
+import { hasCruDomain } from '../config/domains.js'
+```
+
+Replace the field declaration and constructor:
+
+```ts
+  private client: GRClient
+  private okta?: Client
+
+  constructor(accessToken: string, baseUrl: string, okta?: Client) {
+    this.client = new GRClient({ baseUrl, accessToken })
+    this.okta = okta
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: PASS (existing tests + the new constructor test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/global-registry.ts tests/models/global-registry.test.ts
+git commit -m "Inject optional Okta client into GlobalRegistry"
+```
+
+---
+
+## Task 4: `isFieldNotDefinedError` + `findConflictCandidates`
+
+Transition-resilient GR lookup: returns `the_key` person candidates for one identifier filter, treating a "field not defined" 400 as empty.
+
+**Files:**
+- Modify: `src/models/global-registry.ts`
+- Test: `tests/models/global-registry.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new top-level `describe` block in `tests/models/global-registry.test.ts`:
+
+```ts
+  describe('findConflictCandidates( filter, fields )', () => {
+    it('returns entities for a matching filter', async () => {
+      const entities = [{ person: { id: 'p1' } }]
+      mockEntityGET.mockResolvedValue({ entities })
+      const result = await globalRegistry.findConflictCandidates(
+        { account_number: '12345678' },
+        'account_number,hcm_person_number,email_address'
+      )
+      expect(result).toEqual(entities)
+      expect(mockEntityGET).toHaveBeenCalledWith({
+        entity_type: 'person',
+        filters: { owned_by: 'the_key', account_number: '12345678' },
+        fields: 'account_number,hcm_person_number,email_address'
+      })
+    })
+
+    it('returns [] when GR has no entities key', async () => {
+      mockEntityGET.mockResolvedValue({})
+      expect(await globalRegistry.findConflictCandidates({ hcm_person_number: 'x' }, 'f')).toEqual([])
+    })
+
+    it('treats a "field not defined" 400 as empty', async () => {
+      mockEntityGET.mockRejectedValue({
+        statusCode: 400,
+        error: { error: "can't find entity type named 'hcm_person_number' that is a child of \"person\"" }
+      })
+      expect(await globalRegistry.findConflictCandidates({ hcm_person_number: 'x' }, 'f')).toEqual([])
+    })
+
+    it('re-throws any other error', async () => {
+      mockEntityGET.mockRejectedValue({ statusCode: 500, error: 'boom' })
+      await expect(globalRegistry.findConflictCandidates({ account_number: 'x' }, 'f')).rejects.toEqual({
+        statusCode: 500,
+        error: 'boom'
+      })
+    })
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: FAIL — `globalRegistry.findConflictCandidates is not a function`.
+
+- [ ] **Step 3: Implement the methods**
+
+In `src/models/global-registry.ts`, add these methods to the `GlobalRegistry` class (after `isProbablyTestAccount`):
+
+```ts
+  isFieldNotDefinedError(error: unknown): boolean {
+    const err = error as { statusCode?: number; error?: unknown; message?: string }
+    if (err?.statusCode !== 400) {
+      return false
+    }
+    const haystack = `${JSON.stringify(err.error ?? '')} ${err.message ?? ''}`
+    return haystack.includes("can't find entity type named")
+  }
+
+  async findConflictCandidates(
+    identifierFilter: Record<string, string>,
+    fields: string
+  ): Promise<Array<Record<string, unknown>>> {
+    try {
+      const result = await this.client.Entity.get({
+        entity_type: PERSON_ENTITY_TYPE,
+        filters: { owned_by: THE_KEY_SYSYEM, ...identifierFilter },
+        fields
+      })
+      return result.entities ?? []
+    } catch (error) {
+      // During the PSHR->HCM transition a filter field may not be defined on the person
+      // type in a given environment; GR returns a 400 in that case. Treat that single
+      // field's query as "no candidates" and let the other query proceed.
+      if (this.isFieldNotDefinedError(error)) {
+        return []
+      }
+      throw error
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/global-registry.ts tests/models/global-registry.test.ts
+git commit -m "Add transition-resilient GR conflict candidate lookup"
+```
+
+---
+
+## Task 5: `emailAddresses` + `isAccountNumberConflict`
+
+Decide whether a candidate entity is a true conflict.
+
+**Files:**
+- Modify: `src/models/global-registry.ts`
+- Test: `tests/models/global-registry.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new `describe` block in `tests/models/global-registry.test.ts`:
+
+```ts
+  describe('isAccountNumberConflict( entity, profile )', () => {
+    const profile = {
+      theKeyGuid: 'NEW-GUID',
+      login: 'jon.watson@cru.org',
+      usEmployeeId: '12345678'
+    } as any
+
+    it('true: account_number matches, different email, different guid', () => {
+      const entity = {
+        person: {
+          id: 'p1',
+          account_number: '12345678',
+          client_integration_id: 'STALE-GUID',
+          email_address: { email: 'jon@gmail.com' }
+        }
+      }
+      expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(true)
+    })
+
+    it('true: matches on hcm_person_number only', () => {
+      const entity = {
+        person: {
+          id: 'p1',
+          hcm_person_number: '12345678',
+          client_integration_id: 'STALE-GUID',
+          email_address: { email: 'jon@gmail.com' }
+        }
+      }
+      expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(true)
+    })
+
+    it('true: email_address is an array with no matching email', () => {
+      const entity = {
+        person: {
+          id: 'p1',
+          account_number: '12345678',
+          client_integration_id: 'STALE-GUID',
+          email_address: [{ email: 'jon@gmail.com' }, { email: 'jon@yahoo.com' }]
+        }
+      }
+      expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(true)
+    })
+
+    it('false: number does not actually match (loose filter guard)', () => {
+      const entity = {
+        person: {
+          id: 'p1',
+          account_number: '99999999',
+          client_integration_id: 'STALE-GUID',
+          email_address: { email: 'jon@gmail.com' }
+        }
+      }
+      expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(false)
+    })
+
+    it('false: same account being saved (client_integration_id matches theKeyGuid)', () => {
+      const entity = {
+        person: {
+          id: 'p1',
+          account_number: '12345678',
+          client_integration_id: 'NEW-GUID',
+          email_address: { email: 'jon.watson@cru.org' }
+        }
+      }
+      expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(false)
+    })
+
+    it('false: one of the emails matches the saving login', () => {
+      const entity = {
+        person: {
+          id: 'p1',
+          account_number: '12345678',
+          client_integration_id: 'STALE-GUID',
+          email_address: [{ email: 'old@gmail.com' }, { email: 'jon.watson@cru.org' }]
+        }
+      }
+      expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(false)
+    })
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: FAIL — `globalRegistry.isAccountNumberConflict is not a function`.
+
+- [ ] **Step 3: Implement the methods**
+
+Add to the `GlobalRegistry` class in `src/models/global-registry.ts`:
+
+```ts
+  emailAddresses(entity: Record<string, unknown>): string[] {
+    const emailAddress = get(entity, 'person.email_address')
+    const list = Array.isArray(emailAddress) ? emailAddress : [emailAddress]
+    return list
+      .map((item) => get(item, 'email'))
+      .filter((email): email is string => typeof email === 'string')
+  }
+
+  isAccountNumberConflict(entity: Record<string, unknown>, profile: OktaUserProfile): boolean {
+    const accountNumber = get(entity, 'person.account_number')
+    const hcmPersonNumber = get(entity, 'person.hcm_person_number')
+    const clientIntegrationId = get(entity, 'person.client_integration_id')
+
+    // Authoritative match: actually holds this employee number in either identifier field.
+    const numberMatches =
+      equalsIgnoreCase(accountNumber, profile.usEmployeeId) ||
+      equalsIgnoreCase(hcmPersonNumber, profile.usEmployeeId)
+    if (!numberMatches) {
+      return false
+    }
+    // Never the account currently being saved.
+    if (equalsIgnoreCase(clientIntegrationId, profile.theKeyGuid)) {
+      return false
+    }
+    // A different account: none of its emails equal the saving Cru login.
+    return !this.emailAddresses(entity).some((email) => equalsIgnoreCase(email, profile.login))
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/global-registry.ts tests/models/global-registry.test.ts
+git commit -m "Add account_number conflict detection"
+```
+
+---
+
+## Task 6: `releaseAccountNumber`
+
+Clear `account_number` + `hcm_person_number` on a stale `the_key` entity via `Entity.put`.
+
+**Files:**
+- Modify: `src/models/global-registry.ts`
+- Test: `tests/models/global-registry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new `describe` block in `tests/models/global-registry.test.ts`:
+
+```ts
+  describe('releaseAccountNumber( entity )', () => {
+    it('clears account_number and hcm_person_number by person id via PUT', async () => {
+      mockEntityPUT.mockResolvedValue({})
+      await globalRegistry.releaseAccountNumber({ person: { id: 'person-123' } })
+      expect(mockEntityPUT).toHaveBeenCalledWith('person-123', {
+        account_number: null,
+        hcm_person_number: null
+      })
+    })
+  })
+```
+
+Also extend the `vi.mock('global-registry-nodejs-client', ...)` factory at the top of the file to include `mockEntityPUT`, and add it to the import on line 3. The mock factory becomes:
+
+```ts
+import { GRClient, mockEntityGET, mockEntityDELETE, mockEntityPOST, mockEntityPUT } from 'global-registry-nodejs-client'
+import { v4 as uuid } from 'uuid'
+
+vi.mock('global-registry-nodejs-client', async () => {
+  const { mockEntityGET, mockEntityDELETE, mockEntityPOST, mockEntityPUT, GRClient } = await import('../mocks/global-registry-nodejs-client.js')
+  return { GRClient, mockEntityGET, mockEntityDELETE, mockEntityPOST, mockEntityPUT }
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: FAIL — `globalRegistry.releaseAccountNumber is not a function`.
+
+- [ ] **Step 3: Implement the method**
+
+Add to the `GlobalRegistry` class in `src/models/global-registry.ts`:
+
+```ts
+  async releaseAccountNumber(entity: Record<string, unknown>): Promise<void> {
+    const personId = get(entity, 'person.id') as string
+    // PUT /entities/:id updates the loaded person with update-time validations and
+    // partial reconciliation; a null value destroys that field's value-entity.
+    await this.client.Entity.put(personId, {
+      account_number: null,
+      hcm_person_number: null
+    })
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/global-registry.ts tests/models/global-registry.test.ts
+git commit -m "Add releaseAccountNumber to clear stale GR employee number"
+```
+
+---
+
+## Task 7: `clearStaleOktaEmployeeId`
+
+Clear `usEmployeeId` on the stale Okta account (looked up by `theKeyGuid`). Best-effort.
+
+**Files:**
+- Modify: `src/models/global-registry.ts`
+- Test: `tests/models/global-registry.test.ts`
+
+- [ ] **Step 1: Add the rollbar mock and write the failing tests**
+
+At the top of `tests/models/global-registry.test.ts`, after the `global-registry-nodejs-client` mock, add:
+
+```ts
+vi.mock('@/config/rollbar.js')
+```
+
+And add the import near the top:
+
+```ts
+import rollbar from '@/config/rollbar.js'
+```
+
+Add a new `describe` block:
+
+```ts
+  describe('clearStaleOktaEmployeeId( entity )', () => {
+    const entity = { person: { client_integration_id: 'STALE-GUID' } }
+
+    it('does nothing when no Okta client is configured', async () => {
+      const gr = new GlobalRegistry('token', 'https://example.com')
+      await gr.clearStaleOktaEmployeeId(entity)
+      // No throw, nothing to assert beyond completion.
+    })
+
+    it('nulls usEmployeeId on the matched user and updates Okta', async () => {
+      const staleUser = { id: 'okta-stale-id', profile: { theKeyGuid: 'STALE-GUID', usEmployeeId: '12345678' } }
+      const updateUser = vi.fn().mockResolvedValue(undefined)
+      const listUsers = vi.fn().mockResolvedValue({
+        each: (fn: (u: any) => void) => [staleUser].forEach(fn)
+      })
+      const okta = { userApi: { listUsers, updateUser } } as any
+      const gr = new GlobalRegistry('token', 'https://example.com', okta)
+
+      await gr.clearStaleOktaEmployeeId(entity)
+
+      expect(listUsers).toHaveBeenCalledWith({ search: 'profile.theKeyGuid eq "STALE-GUID"' })
+      expect(staleUser.profile.usEmployeeId).toBeNull()
+      expect(updateUser).toHaveBeenCalledWith({ userId: 'okta-stale-id', user: staleUser })
+    })
+
+    it('logs to Rollbar and does not throw when Okta fails', async () => {
+      const listUsers = vi.fn().mockRejectedValue(new Error('okta down'))
+      const okta = { userApi: { listUsers, updateUser: vi.fn() } } as any
+      const gr = new GlobalRegistry('token', 'https://example.com', okta)
+
+      await expect(gr.clearStaleOktaEmployeeId(entity)).resolves.toBeUndefined()
+      expect(rollbar.error).toHaveBeenCalled()
+    })
+
+    it('does nothing when the entity has no client_integration_id', async () => {
+      const okta = { userApi: { listUsers: vi.fn(), updateUser: vi.fn() } } as any
+      const gr = new GlobalRegistry('token', 'https://example.com', okta)
+      await gr.clearStaleOktaEmployeeId({ person: {} })
+      expect(okta.userApi.listUsers).not.toHaveBeenCalled()
+    })
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: FAIL — `gr.clearStaleOktaEmployeeId is not a function`.
+
+- [ ] **Step 3: Implement the method**
+
+Add to the `GlobalRegistry` class in `src/models/global-registry.ts`:
+
+```ts
+  async clearStaleOktaEmployeeId(entity: Record<string, unknown>): Promise<void> {
+    const okta = this.okta
+    if (!okta) {
+      return
+    }
+    const theKeyGuid = get(entity, 'person.client_integration_id') as string | undefined
+    if (!theKeyGuid) {
+      return
+    }
+    try {
+      const collection = await okta.userApi.listUsers({
+        search: `profile.theKeyGuid eq "${theKeyGuid}"`
+      })
+      const matched: User[] = []
+      await collection.each((user: User) => {
+        matched.push(user)
+      })
+      for (const user of matched) {
+        if (user.profile) {
+          const staleProfile = user.profile as Record<string, unknown>
+          staleProfile.usEmployeeId = null
+        }
+        await okta.userApi.updateUser({ userId: user.id!, user })
+      }
+    } catch (error) {
+      // Best-effort: the GR collision is already resolved; only the ping-pong mitigation
+      // is deferred. Surface but do not block onboarding.
+      await rollbar.error(
+        'resolveAccountNumberCollision: failed to clear stale Okta usEmployeeId',
+        error as Error,
+        { theKeyGuid }
+      )
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/global-registry.ts tests/models/global-registry.test.ts
+git commit -m "Add best-effort clearing of stale Okta usEmployeeId"
+```
+
+---
+
+## Task 8: `resolveAccountNumberCollision` orchestration + gate
+
+**Files:**
+- Modify: `src/models/global-registry.ts`
+- Test: `tests/models/global-registry.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new `describe` block in `tests/models/global-registry.test.ts`:
+
+```ts
+  describe('resolveAccountNumberCollision( profile )', () => {
+    let okta: any
+    let updateUser: ReturnType<typeof vi.fn>
+    let listUsers: ReturnType<typeof vi.fn>
+    let gr: GlobalRegistry
+
+    const conflictEntity = (overrides: Record<string, unknown> = {}) => ({
+      person: {
+        id: 'stale-person-id',
+        account_number: '12345678',
+        hcm_person_number: '12345678',
+        client_integration_id: 'STALE-GUID',
+        email_address: { email: 'jon@gmail.com' },
+        ...overrides
+      }
+    })
+
+    const staffProfile = (overrides: Record<string, unknown> = {}) =>
+      ({
+        theKeyGuid: 'NEW-GUID',
+        login: 'jon.watson@cru.org',
+        usEmployeeId: '12345678',
+        ...overrides
+      }) as any
+
+    beforeEach(() => {
+      updateUser = vi.fn().mockResolvedValue(undefined)
+      listUsers = vi.fn().mockResolvedValue({
+        each: (fn: (u: any) => void) =>
+          [{ id: 'okta-stale-id', profile: { theKeyGuid: 'STALE-GUID', usEmployeeId: '12345678' } }].forEach(fn)
+      })
+      okta = { userApi: { listUsers, updateUser } }
+      gr = new GlobalRegistry('token', 'https://example.com', okta)
+      mockEntityPUT.mockResolvedValue({})
+    })
+
+    it.each([
+      ['no usEmployeeId', staffProfile({ usEmployeeId: undefined })],
+      ['test account', staffProfile({ login: 'test.jon@cru.org' })],
+      ['non-Cru email', staffProfile({ login: 'jon@gmail.com' })],
+      ['orca === false', staffProfile({ orca: false })]
+    ])('skips entirely when gated out: %s', async (_label, profile) => {
+      await gr.resolveAccountNumberCollision(profile)
+      expect(mockEntityGET).not.toHaveBeenCalled()
+      expect(mockEntityPUT).not.toHaveBeenCalled()
+      expect(updateUser).not.toHaveBeenCalled()
+    })
+
+    it('proceeds when orca is undefined (treated as onboarded)', async () => {
+      mockEntityGET.mockResolvedValue({ entities: [] })
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityGET).toHaveBeenCalledTimes(2)
+    })
+
+    it('queries both identifier fields', async () => {
+      mockEntityGET.mockResolvedValue({ entities: [] })
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityGET).toHaveBeenCalledWith({
+        entity_type: 'person',
+        filters: { owned_by: 'the_key', account_number: '12345678' },
+        fields: 'account_number,hcm_person_number,email_address'
+      })
+      expect(mockEntityGET).toHaveBeenCalledWith({
+        entity_type: 'person',
+        filters: { owned_by: 'the_key', hcm_person_number: '12345678' },
+        fields: 'account_number,hcm_person_number,email_address'
+      })
+    })
+
+    it('does nothing when there is no conflict', async () => {
+      mockEntityGET.mockResolvedValue({ entities: [] })
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityPUT).not.toHaveBeenCalled()
+      expect(updateUser).not.toHaveBeenCalled()
+    })
+
+    it('clears GR and Okta for a single conflict', async () => {
+      mockEntityGET.mockResolvedValue({ entities: [conflictEntity()] })
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityPUT).toHaveBeenCalledWith('stale-person-id', {
+        account_number: null,
+        hcm_person_number: null
+      })
+      expect(listUsers).toHaveBeenCalledWith({ search: 'profile.theKeyGuid eq "STALE-GUID"' })
+      expect(updateUser).toHaveBeenCalledTimes(1)
+    })
+
+    it('de-duplicates an entity returned by both queries (one PUT)', async () => {
+      // Same conflict entity returned for both account_number and hcm_person_number queries.
+      mockEntityGET.mockResolvedValue({ entities: [conflictEntity()] })
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityPUT).toHaveBeenCalledTimes(1)
+    })
+
+    it('resolves an HCM-only conflict (account_number absent)', async () => {
+      const hcmOnly = conflictEntity({ account_number: undefined })
+      // Only the hcm_person_number query returns it.
+      mockEntityGET
+        .mockResolvedValueOnce({ entities: [] }) // account_number query
+        .mockResolvedValueOnce({ entities: [hcmOnly] }) // hcm_person_number query
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityPUT).toHaveBeenCalledWith('stale-person-id', {
+        account_number: null,
+        hcm_person_number: null
+      })
+    })
+
+    it('continues when one field query 400s (field not defined)', async () => {
+      mockEntityGET
+        .mockResolvedValueOnce({ entities: [conflictEntity()] }) // account_number query
+        .mockRejectedValueOnce({
+          statusCode: 400,
+          error: { error: "can't find entity type named 'hcm_person_number' that is a child of \"person\"" }
+        })
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityPUT).toHaveBeenCalledTimes(1)
+    })
+
+    it('propagates a non-field GR error from a query', async () => {
+      mockEntityGET.mockRejectedValue({ statusCode: 500, error: 'boom' })
+      await expect(gr.resolveAccountNumberCollision(staffProfile())).rejects.toBeDefined()
+    })
+
+    it('propagates a GR PUT failure (required step)', async () => {
+      mockEntityGET.mockResolvedValue({ entities: [conflictEntity()] })
+      mockEntityPUT.mockRejectedValue(new Error('put failed'))
+      await expect(gr.resolveAccountNumberCollision(staffProfile())).rejects.toThrow('put failed')
+    })
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: FAIL — `gr.resolveAccountNumberCollision is not a function`.
+
+- [ ] **Step 3: Implement the method**
+
+Add to the `GlobalRegistry` class in `src/models/global-registry.ts`:
+
+```ts
+  async resolveAccountNumberCollision(profile: OktaUserProfile): Promise<void> {
+    const employeeId = profile.usEmployeeId
+    if (
+      !employeeId ||
+      this.isProbablyTestAccount(profile.login) ||
+      !hasCruDomain(profile.login) ||
+      profile.orca === false
+    ) {
+      return
+    }
+
+    const fields = 'account_number,hcm_person_number,email_address'
+    const [byAccountNumber, byHcmPersonNumber] = await Promise.all([
+      this.findConflictCandidates({ account_number: employeeId }, fields),
+      this.findConflictCandidates({ hcm_person_number: employeeId }, fields)
+    ])
+
+    const candidatesById = new Map<string, Record<string, unknown>>()
+    for (const entity of [...byAccountNumber, ...byHcmPersonNumber]) {
+      const personId = get(entity, 'person.id') as string | undefined
+      if (personId) {
+        candidatesById.set(personId, entity)
+      }
+    }
+
+    for (const entity of candidatesById.values()) {
+      if (this.isAccountNumberConflict(entity, profile)) {
+        // GR clear is required (runs before the new entity is posted); a failure
+        // propagates because the subsequent post would collide anyway.
+        await this.releaseAccountNumber(entity)
+        // Okta clear is best-effort (logged, never blocks onboarding).
+        await this.clearStaleOktaEmployeeId(entity)
+      }
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/global-registry.ts tests/models/global-registry.test.ts
+git commit -m "Add resolveAccountNumberCollision orchestration and gate"
+```
+
+---
+
+## Task 9: Run collision resolution inside `createOrUpdateProfile`
+
+**Files:**
+- Modify: `src/models/global-registry.ts:27-31` (`createOrUpdateProfile`)
+- Test: `tests/models/global-registry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/models/global-registry.test.ts`, inside the existing `describe('createOrUpdateProfile( profile )', ...)` block, add a test:
+
+```ts
+    it('resolves account_number collisions before posting the entity', async () => {
+      const order: string[] = []
+      vi.spyOn(globalRegistry, 'resolveAccountNumberCollision').mockImplementation(async () => {
+        order.push('resolve')
+      })
+      mockEntityPOST.mockImplementation(async () => {
+        order.push('post')
+        return { entity: { person: { id: uuid() } } }
+      })
+      await globalRegistry.createOrUpdateProfile(profile)
+      expect(globalRegistry.resolveAccountNumberCollision).toHaveBeenCalledWith(profile)
+      expect(order).toEqual(['resolve', 'post'])
+    })
+```
+
+Also add, to the existing `describe('createOrUpdateProfile( profile )', ...)` `beforeEach`, a spy so the other createOrUpdateProfile tests stay isolated from the new behavior:
+
+```ts
+      vi.spyOn(globalRegistry, 'resolveAccountNumberCollision').mockResolvedValue(undefined)
+```
+
+(Place it alongside the existing `vi.spyOn(globalRegistry, 'buildPersonEntity')...` and `vi.spyOn(globalRegistry, 'deleteDesignationRelationshipIfNecessary')...` lines. The new ordering test re-overrides the spy with its own `mockImplementation`, which is fine.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: FAIL — order is `['post']` only / `resolveAccountNumberCollision` not called.
+
+- [ ] **Step 3: Wire it into `createOrUpdateProfile`**
+
+In `src/models/global-registry.ts`, add the call as the first line of `createOrUpdateProfile` (before `buildPersonEntity`):
+
+```ts
+  async createOrUpdateProfile(profile: OktaUserProfile): Promise<boolean> {
+    await this.resolveAccountNumberCollision(profile)
+
+    const personEntity = await this.buildPersonEntity(profile)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -- tests/models/global-registry.test.ts`
+Expected: PASS (including all pre-existing createOrUpdateProfile tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/global-registry.ts tests/models/global-registry.test.ts
+git commit -m "Run account_number collision resolution before posting GR entity"
+```
+
+---
+
+## Task 10: Pass the Okta client into GlobalRegistry from the handlers
+
+**Files:**
+- Modify: `src/handlers/sns/user-lifecycle-create.ts:11-14`
+- Modify: `src/handlers/sns/user-lifecycle-status-change.ts:10-13`
+- Modify: `src/handlers/sns/user-account-update-profile.ts:10-13`
+
+These three handlers already construct `const okta = new Client(...)` and `new GlobalRegistry(token, url)`. Add `okta` as the third argument in each.
+
+- [ ] **Step 1: Update `user-lifecycle-create.ts`**
+
+Change the `GlobalRegistry` construction to:
+
+```ts
+  const globalRegistry = new GlobalRegistry(
+    process.env.GLOBAL_REGISTRY_TOKEN!,
+    process.env.GLOBAL_REGISTRY_URL!,
+    okta
+  )
+```
+
+- [ ] **Step 2: Update `user-lifecycle-status-change.ts`**
+
+Make the identical change to its `GlobalRegistry` construction (add `,\n    okta` as the third argument).
+
+- [ ] **Step 3: Update `user-account-update-profile.ts`**
+
+Make the identical change to its `GlobalRegistry` construction (add `,\n    okta` as the third argument).
+
+- [ ] **Step 4: Run the handler test suites**
+
+Run: `npm run test -- tests/handlers/sns`
+Expected: PASS. (Handler tests mock `GlobalRegistry`, so the extra constructor argument is accepted without assertion changes.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/handlers/sns/user-lifecycle-create.ts src/handlers/sns/user-lifecycle-status-change.ts src/handlers/sns/user-account-update-profile.ts
+git commit -m "Pass Okta client into GlobalRegistry for collision resolution"
+```
+
+---
+
+## Task 11: Full verification
+
+- [ ] **Step 1: Type-check**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 3: Full test suite with coverage**
+
+Run: `npm run test`
+Expected: all tests PASS.
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: builds successfully.
+
+- [ ] **Step 5: Commit any lint fixups**
+
+```bash
+git add -A
+git commit -m "Lint and verification fixups"
+```
+
+(Skip if nothing changed.)
+
+---
+
+## Self-Review Notes (coverage map)
+
+- **Spec gate (usEmployeeId / test account / Cru domain / orca):** Task 8 (`resolveAccountNumberCollision`), Task 1 (`hasCruDomain`).
+- **Dual lookup + union + transition resilience:** Tasks 4 and 8.
+- **Conflict selection (either field, email mismatch, self-exclusion, object-or-array email):** Task 5.
+- **GR clear via PUT (required):** Task 6; failure propagation verified in Task 8.
+- **Okta `usEmployeeId` clear by theKeyGuid (best-effort):** Task 7.
+- **Runs before the post, all 3 callers:** Tasks 9 and 10.
+- **Types/mocks support:** Task 2.

--- a/docs/superpowers/specs/2026-06-09-gr-account-number-collision-design.md
+++ b/docs/superpowers/specs/2026-06-09-gr-account-number-collision-design.md
@@ -79,7 +79,7 @@ If any condition is false, skip resolution and proceed exactly as today.
    both must be searched:
 
    ```ts
-   const fields = 'account_number,hcm_person_number,email_address'
+   const fields = 'account_number,hcm_person_number'
    const byAccountNumber = Entity.get({
      entity_type: 'person',
      filters: { owned_by: 'the_key', account_number: profile.usEmployeeId },
@@ -107,18 +107,17 @@ If any condition is false, skip resolution and proceed exactly as today.
    filterable, and unknown filters 400 (GR does not silently ignore them).
 
 2. **Select true conflicts.** Read fields off `entity.person` (verified shape — see
-   Assumptions #3). For each unique candidate, treat it as a conflict **only if all**
-   hold:
+   Assumptions #3). The uniqueness constraint is on the identifier fields only, so the
+   conflict test is purely identifier-based — email is **not** part of it. Treat a
+   candidate as a conflict **only if both** hold:
    - **Either** `person.account_number` **or** `person.hcm_person_number` is populated and
      `equalsIgnoreCase(String(field), String(profile.usEmployeeId))` (authoritative
      equality check — does not trust the filters alone, and guards against no-op writes),
      **and**
-   - **none** of the candidate's email addresses `equalsIgnoreCase` `profile.login`
-     (normalize `person.email_address` to an array first, since it may be a single object
-     or an array; a non-matching email means it belongs to a different account — the stale
-     personal account), **and**
-   - `person.client_integration_id` !== `profile.theKeyGuid` (defensive: never the account
-     being saved).
+   - `person.client_integration_id` !== `profile.theKeyGuid` — i.e. **any** `the_key`
+     entity other than the one being saved that holds this number is a collision. GR
+     forbids two `the_key` entities sharing the number, so the saving account is the only
+     legitimate holder; everything else must be cleared regardless of email.
 
 3. **For each true conflict:**
    1. **Strip GR `account_number` and `hcm_person_number`** —
@@ -206,14 +205,13 @@ three handlers that call `createOrUpdateProfile`.
    } }
    ```
 
-   Extraction paths: `entity.person.id`, `entity.person.account_number`,
-   `entity.person.hcm_person_number`, `entity.person.client_integration_id`,
-   `entity.person.email_address.email`. `email_address` returned as a single object here
-   (one email); since a person may have several and GR returns arrays for multi-valued
-   fields (cf. `master_person:relationship`, already handled both ways in this codebase),
-   extraction must normalize object-or-array. Observed hit rate in a 1000-record sample:
-   14 with `account_number`, 7 with `hcm_person_number` — confirms both lookups are
-   needed during the transition.
+   Extraction paths used: `entity.person.id`, `entity.person.account_number`,
+   `entity.person.hcm_person_number`, `entity.person.client_integration_id` (the last two
+   come back even though only the identifier fields are requested in `fields`). Email is
+   **not** consulted (the conflict test is identifier-only), so `email_address` is no
+   longer requested or read — the shape above is retained for reference only. Observed hit
+   rate in a 1000-record sample: 14 with `account_number`, 7 with `hcm_person_number` —
+   confirms both lookups are needed during the transition.
 4. ✅ **Confirmed working-as-designed.** GR's uniqueness rejection on the new post is
    driven only by collisions among `the_key`-owned entities (the `account_number` /
    `hcm_person_number` scalar fields). `linked_identities.{hcm,pshr,siebel}` live in
@@ -233,9 +231,12 @@ proceeding.
   no Okta update, normal post proceeds.
 - **Gate misses:** each of (no `usEmployeeId`, test account, non-Cru email,
   `orca === false`) → resolution skipped entirely.
-- **Single conflict:** stale entity with same `account_number`, different email →
-  `Entity.put(id, { account_number: null, hcm_person_number: null })` called, stale Okta
-  user's `usEmployeeId` cleared via `updateUser`, then post proceeds.
+- **Single conflict:** another `the_key` entity with the same `account_number` (different
+  `client_integration_id`) → `Entity.put(id, { account_number: null, hcm_person_number:
+  null })` called, stale Okta user's `usEmployeeId` cleared via `updateUser`, then post
+  proceeds.
+- **Email is irrelevant:** a conflict is cleared even if one of its emails equals the
+  saving login — only the identifier fields and `client_integration_id` matter.
 - **Legacy stale entity (no `hcm_person_number`):** found via the `account_number` query;
   PUT still clears both fields (`hcm_person_number: null` is a harmless no-op).
 - **HCM-only stale entity (no `account_number`):** found via the `hcm_person_number`

--- a/docs/superpowers/specs/2026-06-09-gr-account-number-collision-design.md
+++ b/docs/superpowers/specs/2026-06-09-gr-account-number-collision-design.md
@@ -1,0 +1,248 @@
+# GR `account_number` collision resolution
+
+- **Date:** 2026-06-09
+- **Status:** Approved (design)
+- **Component:** okta-hooks — `src/models/global-registry.ts`
+
+## Background
+
+okta-hooks creates and maintains a `the_key`-owned Global Registry (GR) person entity
+for each Okta account. When the Okta profile has a `usEmployeeId`, `buildPersonEntity`
+writes that value to **both** the entity's `account_number` field **and** its
+`hcm_person_number` field (and to `linked_identities.{hcm,pshr,siebel}`). The
+`hcm_person_number` / `hcm` linked identity were added in PR #91 (merged 2026-04-02).
+
+GR enforces a **uniqueness constraint on `account_number` *and* on `hcm_person_number`
+for `the_key`-owned person entities** — two `the_key` person entities cannot share the
+same value in either field. Both must be freed on the stale entity, or the new entity's
+post still collides on whichever field is left.
+
+### The edge case
+
+Some job codes onboard a person **without** granting a Cru-domain email
+(`GRANT_EMAIL == N`, `SYSTEM_ONBOARD == Y`). In that flow no new Okta account is
+created; the person's **existing personal account** (personal/non-Cru email) is modified
+in place to onboard them, and a `usEmployeeId` is assigned. okta-hooks then writes that
+employee number to the `account_number` of the personal account's `the_key` GR entity.
+
+Later the person stops working for Cru, but their personal Okta account stays active
+(donations, other systems). The `account_number` remains populated on that entity.
+
+When the same person returns as full staff **with** a Cru-domain email, onboarding's
+anti-hijacking policy creates a **separate** Okta work account, leaving the personal
+account untouched. Both accounts now carry the same `usEmployeeId`. Okta allows this,
+but when okta-hooks tries to save the new work account's `the_key` person entity, the
+GR `account_number` uniqueness constraint **collides** with the old personal-account
+entity, and the new entity cannot be saved.
+
+## Goal
+
+Before saving the new (Cru-email, onboarded) work account's GR person entity, detect any
+`the_key` person entity that already holds the same employee number (in `account_number`
+and/or `hcm_person_number`) for a *different* account, and release it — clearing both
+fields in GR and clearing `usEmployeeId` on the stale Okta account — so the new entity
+saves cleanly and the conflict does not recur.
+
+## Scope / non-goals
+
+- **In scope:** clearing `account_number` **and** `hcm_person_number` on conflicting
+  `the_key`-owned GR person entities, and clearing `usEmployeeId` on the corresponding
+  stale Okta accounts.
+- **Out of scope:** `linked_identities.{hcm,pshr,siebel}` are **not** modified (only the
+  two top-level fields are cleared, and only on `the_key`-owned records — this is also all
+  the okta-hooks GR token is expected to have access to). Entities owned by other systems
+  (e.g. `pshr`, `hcm`) are never touched. The uniqueness constraint only applies among
+  `the_key`-owned entities; `linked_identities.{hcm,pshr,siebel}` live in other systems'
+  namespaces and do not block the new post (confirmed — see Assumptions #4), so clearing
+  the two scalar fields on the stale `the_key` entity is sufficient.
+
+## Trigger / gate
+
+A new resolution step runs at the **top of `createOrUpdateProfile`, before any entity is
+posted**, only when **all** of the following hold for the account being saved:
+
+1. `profile.usEmployeeId` is present (there is an `account_number` to claim).
+2. `!isProbablyTestAccount(profile.login)` — mirrors `buildPersonEntity`; test accounts
+   never receive an `account_number`, so they can never collide.
+3. `hasCruDomain(profile.login)` — **step 1**: the saving account has a Cru email.
+4. `profile.orca !== false` — **step 2**: the account is supposed to be onboarded
+   (`true` and `undefined` both pass; only an explicit `false` is excluded).
+
+If any condition is false, skip resolution and proceed exactly as today.
+
+## Resolution algorithm (steps 3 & 4)
+
+1. **Query GR** for candidate conflicts on **both** identifier fields, explicitly
+   retrieving the fields needed to verify the conflict. The employee number lives in
+   `account_number` today (PSHR) and is migrating to `hcm_person_number` (Oracle HCM);
+   during and after the transition a stale entity may carry the value in either field, so
+   both must be searched:
+
+   ```ts
+   const fields = 'account_number,hcm_person_number,email_address'
+   const byAccountNumber = Entity.get({
+     entity_type: 'person',
+     filters: { owned_by: 'the_key', account_number: profile.usEmployeeId },
+     fields
+   })
+   const byHcmPersonNumber = Entity.get({
+     entity_type: 'person',
+     filters: { owned_by: 'the_key', hcm_person_number: profile.usEmployeeId },
+     fields
+   })
+   ```
+
+   **Union** the two result sets, de-duplicating by `person.id` (an entity carrying the
+   value in both fields is returned by both queries).
+
+   **Transition resilience.** Each query is run and handled independently. GR returns an
+   empty set (not an error) when a *defined* field has no match, but it returns a **400**
+   (`can't find entity type named '<field>' that is a child of 'person'`) if the field is
+   not defined on the `person` type at all. Because the employee number is migrating
+   `account_number` → `hcm_person_number`, a field may be undefined in a given
+   environment at some point in the transition. Therefore: if a single field's query
+   fails with that "field not defined" 400, treat it as an empty result and continue with
+   the other query rather than aborting. Any other error (auth, network, a different 400)
+   propagates. Verified against stage 2026-06-09: both fields are currently defined and
+   filterable, and unknown filters 400 (GR does not silently ignore them).
+
+2. **Select true conflicts.** Read fields off `entity.person` (verified shape — see
+   Assumptions #3). For each unique candidate, treat it as a conflict **only if all**
+   hold:
+   - **Either** `person.account_number` **or** `person.hcm_person_number` is populated and
+     `equalsIgnoreCase(String(field), String(profile.usEmployeeId))` (authoritative
+     equality check — does not trust the filters alone, and guards against no-op writes),
+     **and**
+   - **none** of the candidate's email addresses `equalsIgnoreCase` `profile.login`
+     (normalize `person.email_address` to an array first, since it may be a single object
+     or an array; a non-matching email means it belongs to a different account — the stale
+     personal account), **and**
+   - `person.client_integration_id` !== `profile.theKeyGuid` (defensive: never the account
+     being saved).
+
+3. **For each true conflict:**
+   1. **Strip GR `account_number` and `hcm_person_number`** —
+      `Entity.put(person.id, { account_number: null, hcm_person_number: null })`.
+      Only these two fields, only on the `the_key`-owned record (`hcm_person_number: null`
+      is harmless if the field was unset on a legacy entity). **Required** before the new
+      entity is posted; a failure here propagates (the subsequent post would collide
+      anyway).
+   2. **Clear stale Okta `usEmployeeId`** — locate the stale Okta account by its
+      `theKeyGuid`, which equals the conflict entity's `person.client_integration_id`
+      (unambiguous join; avoids choosing among possibly-multiple emails):
+      `listUsers({ search: 'profile.theKeyGuid eq "<client_integration_id>"' })`. For the
+      matched user, set `profile.usEmployeeId = null` (Okta's convention for clearing a
+      custom attribute; `undefined` would be omitted from the payload and clear nothing)
+      and `updateUser(...)`. This stops the stale account from re-claiming the number on
+      its next sync. **Best-effort:** on failure or no match, log to Rollbar and continue
+      (the immediate collision is already resolved; only the ping-pong mitigation is
+      deferred).
+
+4. **Fall through** to the existing flow: `deleteDesignationRelationshipIfNecessary`
+   then `Entity.post`.
+
+## Code changes
+
+- **`src/config/domains.ts`** (new) — port `googleManagedDomains` and `hasCruDomain()`
+  from us-onboarding as a self-contained copy. (Accepted cross-repo duplication / drift
+  risk over a shared package for now.)
+- **`src/types/okta.ts`** — add `orca?: boolean`.
+- **`src/models/global-registry.ts`**:
+  - Constructor accepts an optional Okta `Client` (`constructor(accessToken, baseUrl, okta?)`).
+  - New private `resolveAccountNumberCollision(profile)` implementing the algorithm above.
+  - Call it at the top of `createOrUpdateProfile`.
+- **Callers that pass their Okta client into `GlobalRegistry`** (the three handlers that
+  call `createOrUpdateProfile`; `sync-missing-okta-users` is *not* one — it only
+  re-publishes `user.lifecycle.create` SNS events, which re-enter via the create handler):
+  - `src/handlers/sns/user-lifecycle-create.ts`
+  - `src/handlers/sns/user-lifecycle-status-change.ts`
+  - `src/handlers/sns/user-account-update-profile.ts`
+- **`src/types/global-registry-nodejs-client.d.ts`** — expose `put(id, content, options?)`
+  (already implemented in the underlying lib) on `EntityClient`; add optional `fields`
+  to `EntityGetOptions`.
+- **`tests/mocks/global-registry-nodejs-client.ts`** — add `mockEntityPUT` and wire it
+  into the `GRClient` mock.
+
+## Error handling (Decision B)
+
+- GR `account_number` strip: **required** before post; failure propagates (existing
+  Rollbar-and-throw behavior in each handler).
+- Stale Okta `usEmployeeId` clear: **best-effort**; log to Rollbar on failure or when no
+  matching user is found, then continue so onboarding completes.
+
+## Architectural note
+
+Placing the resolution inside `createOrUpdateProfile` (per decision) means the
+`GlobalRegistry` model now depends on an Okta `Client` to clear the stale account's
+`usEmployeeId`. This is a deliberate, scoped coupling: the Okta client is injected
+(optional) so existing GR-only unit tests remain valid, and the collision logic that
+spans both systems stays in one place rather than being fragmented across the four
+three handlers that call `createOrUpdateProfile`.
+
+## Assumptions to verify during implementation
+
+1. ✅ **Verified (stage, 2026-06-09).** GR `Entity.get` supports filtering by
+   `account_number` **and** by `hcm_person_number`; an unmatched value returns an empty
+   set, and an undefined filter field returns a 400 (does not silently match all). See
+   the transition-resilience note in the algorithm.
+2. ✅ **Verified (GR source, 2026-06-09).** `Entity.put(id, { account_number: null,
+   hcm_person_number: null })` is a **partial** update: `entities_controller#update`
+   reconciles only the properties present in the payload (omitted fields are untouched),
+   and a blank/nil value `destroy`s that property's value-entity (clears the field) —
+   see `Entity#set_value_without_details`. It also only affects value-entities the
+   token's system created (`find_current_entities` filters by
+   `created_by: Thread.current[:system].id`), so okta-hooks' `the_key` token can only
+   clear `the_key`-owned data — consistent with scope.
+3. ✅ **Verified (stage, 2026-06-09).** A real `the_key` person carrying both fields
+   returns this shape (scalar fields are **omitted when unset**, not returned as null):
+
+   ```json
+   { "person": {
+       "id": "…",
+       "account_number": "<string>",
+       "hcm_person_number": "<string>",
+       "email_address": { "id": "…", "email": "<string>", "client_integration_id": "…" },
+       "client_integration_id": "…"
+   } }
+   ```
+
+   Extraction paths: `entity.person.id`, `entity.person.account_number`,
+   `entity.person.hcm_person_number`, `entity.person.client_integration_id`,
+   `entity.person.email_address.email`. `email_address` returned as a single object here
+   (one email); since a person may have several and GR returns arrays for multi-valued
+   fields (cf. `master_person:relationship`, already handled both ways in this codebase),
+   extraction must normalize object-or-array. Observed hit rate in a 1000-record sample:
+   14 with `account_number`, 7 with `hcm_person_number` — confirms both lookups are
+   needed during the transition.
+4. ✅ **Confirmed working-as-designed.** GR's uniqueness rejection on the new post is
+   driven only by collisions among `the_key`-owned entities (the `account_number` /
+   `hcm_person_number` scalar fields). `linked_identities.{hcm,pshr,siebel}` live in
+   other systems' namespaces and do **not** block the post, so clearing the two scalar
+   fields on the stale `the_key` entity is sufficient.
+
+If any does not hold, mechanics change (e.g. POST-upsert by `client_integration_id`
+instead of PUT; or client-side filtering of a broader query) — flag and adjust before
+proceeding.
+
+## Test plan (Vitest)
+
+`tests/models/global-registry.test.ts` — new `resolveAccountNumberCollision` /
+`createOrUpdateProfile` cases:
+
+- **No collision:** both queries return only the saving account (or empty) → no PUT,
+  no Okta update, normal post proceeds.
+- **Gate misses:** each of (no `usEmployeeId`, test account, non-Cru email,
+  `orca === false`) → resolution skipped entirely.
+- **Single conflict:** stale entity with same `account_number`, different email →
+  `Entity.put(id, { account_number: null, hcm_person_number: null })` called, stale Okta
+  user's `usEmployeeId` cleared via `updateUser`, then post proceeds.
+- **Legacy stale entity (no `hcm_person_number`):** found via the `account_number` query;
+  PUT still clears both fields (`hcm_person_number: null` is a harmless no-op).
+- **HCM-only stale entity (no `account_number`):** found via the `hcm_person_number`
+  query; treated as a conflict and both fields cleared.
+- **Entity in both result sets:** de-duplicated by `person.id`; stripped once.
+- **Multiple conflicts:** all stale entities stripped; all stale Okta users cleared.
+- **`account_number` not populated / not equal:** candidate skipped (no PUT).
+- **Okta clear fails / user not found:** Rollbar logged, post still proceeds.
+- **GR strip fails:** error propagates (no post).
+- Plus unit tests for `hasCruDomain()` in `tests/config/domains.test.ts`.

--- a/src/config/domains.ts
+++ b/src/config/domains.ts
@@ -1,0 +1,39 @@
+/**
+ * Cru email-domain classification.
+ *
+ * Ported from us-onboarding (src/config/domains.ts) and kept self-contained here to
+ * avoid a cross-repo dependency. If the canonical list changes there, update it here too.
+ */
+
+export const googleManagedDomains: string[] = [
+  'cru.org',
+  'allvox.com',
+  'arrowheadconferences.org',
+  'athletesinaction.org',
+  'bridgesinternational.com',
+  'cembassy.org',
+  'crumilitary.org',
+  'designmovement.org',
+  'destino.org',
+  'epicmovement.com',
+  'facultycommons.org',
+  'familylife.com',
+  'isponline.org',
+  'jesusfilm.org',
+  'sightlineministry.org',
+  'unto.com',
+  'campuscrusadeforchrist.com',
+  'ccci.org',
+  'cru.comm',
+  'crusade.org',
+  'keynote.org',
+  'studentventure.com'
+]
+
+/**
+ * True when the email's domain is one of Cru's Google-managed (work) domains.
+ */
+export function hasCruDomain(email: string): boolean {
+  const domain = email?.split('@')[1]?.toLowerCase()
+  return domain ? googleManagedDomains.includes(domain) : false
+}

--- a/src/config/domains.ts
+++ b/src/config/domains.ts
@@ -2,7 +2,8 @@
  * Cru email-domain classification.
  *
  * Ported from us-onboarding (src/config/domains.ts) and kept self-contained here to
- * avoid a cross-repo dependency. If the canonical list changes there, update it here too.
+ * avoid a cross-repo dependency. The same list is duplicated in us-onboarding and celigo;
+ * if the canonical list changes in any of them, keep the others in sync.
  */
 
 export const googleManagedDomains: string[] = [

--- a/src/handlers/sns/user-account-update-profile.ts
+++ b/src/handlers/sns/user-account-update-profile.ts
@@ -9,7 +9,8 @@ export const handler = async (lambdaEvent: SNSEvent): Promise<void> => {
   const okta = new Client({ cacheMiddleware: null })
   const globalRegistry = new GlobalRegistry(
     process.env.GLOBAL_REGISTRY_TOKEN!,
-    process.env.GLOBAL_REGISTRY_URL!
+    process.env.GLOBAL_REGISTRY_URL!,
+    okta
   )
   try {
     const request = new OktaEvent(lambdaEvent.Records[0].Sns.Message)

--- a/src/handlers/sns/user-lifecycle-create.ts
+++ b/src/handlers/sns/user-lifecycle-create.ts
@@ -10,7 +10,8 @@ export const handler = async (lambdaEvent: SNSEvent): Promise<void> => {
   const okta = new Client({ cacheMiddleware: null })
   const globalRegistry = new GlobalRegistry(
     process.env.GLOBAL_REGISTRY_TOKEN!,
-    process.env.GLOBAL_REGISTRY_URL!
+    process.env.GLOBAL_REGISTRY_URL!,
+    okta
   )
   try {
     const request = new OktaEvent(lambdaEvent.Records[0].Sns.Message)

--- a/src/handlers/sns/user-lifecycle-status-change.ts
+++ b/src/handlers/sns/user-lifecycle-status-change.ts
@@ -9,7 +9,8 @@ export const handler = async (lambdaEvent: SNSEvent): Promise<void> => {
   const okta = new Client({ cacheMiddleware: null })
   const globalRegistry = new GlobalRegistry(
     process.env.GLOBAL_REGISTRY_TOKEN!,
-    process.env.GLOBAL_REGISTRY_URL!
+    process.env.GLOBAL_REGISTRY_URL!,
+    okta
   )
   try {
     const event = new OktaEvent(lambdaEvent.Records[0].Sns.Message)

--- a/src/models/global-registry.ts
+++ b/src/models/global-registry.ts
@@ -2,6 +2,7 @@ import { GRClient } from 'global-registry-nodejs-client'
 import { endsWith, startsWith, get, find } from 'lodash'
 import equalsIgnoreCase from '../utils/equals-ignore-case.js'
 import type { OktaUserProfile } from '../types/okta.js'
+import type { Client } from '@okta/okta-sdk-nodejs'
 
 export const PERSON_ENTITY_TYPE = 'person'
 export const PERSON_DESIGNATION_ENTITY_TYPE = 'person_person_designation_designation'
@@ -19,9 +20,11 @@ interface DesignationRelationshipEntity {
 
 class GlobalRegistry {
   private client: GRClient
+  private okta?: Client
 
-  constructor(accessToken: string, baseUrl: string) {
+  constructor(accessToken: string, baseUrl: string, okta?: Client) {
     this.client = new GRClient({ baseUrl, accessToken })
+    this.okta = okta
   }
 
   async createOrUpdateProfile(profile: OktaUserProfile): Promise<boolean> {

--- a/src/models/global-registry.ts
+++ b/src/models/global-registry.ts
@@ -198,6 +198,16 @@ class GlobalRegistry {
     await this.client.Entity.delete(relationshipEntityId)
   }
 
+  async releaseAccountNumber(entity: Record<string, unknown>): Promise<void> {
+    const personId = get(entity, 'person.id') as string
+    // PUT /entities/:id updates the loaded person with update-time validations and
+    // partial reconciliation; a null value destroys that field's value-entity.
+    await this.client.Entity.put(personId, {
+      account_number: null,
+      hcm_person_number: null
+    })
+  }
+
   isFieldNotDefinedError(error: unknown): boolean {
     const err = error as { statusCode?: number; error?: unknown; message?: string }
     if (err?.statusCode !== 400) {

--- a/src/models/global-registry.ts
+++ b/src/models/global-registry.ts
@@ -2,7 +2,8 @@ import { GRClient } from 'global-registry-nodejs-client'
 import { endsWith, startsWith, get, find } from 'lodash'
 import equalsIgnoreCase from '../utils/equals-ignore-case.js'
 import type { OktaUserProfile } from '../types/okta.js'
-import type { Client } from '@okta/okta-sdk-nodejs'
+import type { Client, User } from '@okta/okta-sdk-nodejs'
+import rollbar from '../config/rollbar.js'
 
 export const PERSON_ENTITY_TYPE = 'person'
 export const PERSON_DESIGNATION_ENTITY_TYPE = 'person_person_designation_designation'
@@ -206,6 +207,41 @@ class GlobalRegistry {
       account_number: null,
       hcm_person_number: null
     })
+  }
+
+  async clearStaleOktaEmployeeId(entity: Record<string, unknown>): Promise<void> {
+    const okta = this.okta
+    if (!okta) {
+      return
+    }
+    const theKeyGuid = get(entity, 'person.client_integration_id') as string | undefined
+    if (!theKeyGuid) {
+      return
+    }
+    try {
+      const collection = await okta.userApi.listUsers({
+        search: `profile.theKeyGuid eq "${theKeyGuid}"`
+      })
+      const matched: User[] = []
+      await collection.each((user: User) => {
+        matched.push(user)
+      })
+      for (const user of matched) {
+        if (user.profile) {
+          const staleProfile = user.profile as Record<string, unknown>
+          staleProfile.usEmployeeId = null
+        }
+        await okta.userApi.updateUser({ userId: user.id!, user })
+      }
+    } catch (error) {
+      // Best-effort: the GR collision is already resolved; only the ping-pong mitigation
+      // is deferred. Surface but do not block onboarding.
+      await rollbar.error(
+        'resolveAccountNumberCollision: failed to clear stale Okta usEmployeeId',
+        error as Error,
+        { theKeyGuid }
+      )
+    }
   }
 
   isFieldNotDefinedError(error: unknown): boolean {

--- a/src/models/global-registry.ts
+++ b/src/models/global-registry.ts
@@ -30,6 +30,8 @@ class GlobalRegistry {
   }
 
   async createOrUpdateProfile(profile: OktaUserProfile): Promise<boolean> {
+    await this.resolveAccountNumberCollision(profile)
+
     const personEntity = await this.buildPersonEntity(profile)
 
     await this.deleteDesignationRelationshipIfNecessary(profile)

--- a/src/models/global-registry.ts
+++ b/src/models/global-registry.ts
@@ -278,14 +278,6 @@ class GlobalRegistry {
     }
   }
 
-  emailAddresses(entity: Record<string, unknown>): string[] {
-    const emailAddress = get(entity, 'person.email_address')
-    const list = Array.isArray(emailAddress) ? emailAddress : [emailAddress]
-    return list
-      .map((item) => get(item, 'email'))
-      .filter((email): email is string => typeof email === 'string')
-  }
-
   isAccountNumberConflict(entity: Record<string, unknown>, profile: OktaUserProfile): boolean {
     const accountNumber = get(entity, 'person.account_number')
     const hcmPersonNumber = get(entity, 'person.hcm_person_number')
@@ -298,12 +290,10 @@ class GlobalRegistry {
     if (!numberMatches) {
       return false
     }
-    // Never the account currently being saved.
-    if (equalsIgnoreCase(clientIntegrationId, profile.theKeyGuid)) {
-      return false
-    }
-    // A different account: none of its emails equal the saving Cru login.
-    return !this.emailAddresses(entity).some((email) => equalsIgnoreCase(email, profile.login))
+    // Any the_key entity other than the one being saved that holds this number is a
+    // collision (GR enforces uniqueness on account_number / hcm_person_number for the_key).
+    // Email is not part of the conflict — only the identifier fields are constrained.
+    return !equalsIgnoreCase(clientIntegrationId, profile.theKeyGuid)
   }
 
   isProbablyTestAccount(email: string | undefined): boolean {
@@ -331,7 +321,7 @@ class GlobalRegistry {
       return
     }
 
-    const fields = 'account_number,hcm_person_number,email_address'
+    const fields = 'account_number,hcm_person_number'
     const [byAccountNumber, byHcmPersonNumber] = await Promise.all([
       this.findConflictCandidates({ account_number: employeeId }, fields),
       this.findConflictCandidates({ hcm_person_number: employeeId }, fields)

--- a/src/models/global-registry.ts
+++ b/src/models/global-registry.ts
@@ -1,6 +1,7 @@
 import { GRClient } from 'global-registry-nodejs-client'
 import { endsWith, startsWith, get, find } from 'lodash'
 import equalsIgnoreCase from '../utils/equals-ignore-case.js'
+import { hasCruDomain } from '../config/domains.js'
 import type { OktaUserProfile } from '../types/okta.js'
 import type { Client, User } from '@okta/okta-sdk-nodejs'
 import rollbar from '../config/rollbar.js'
@@ -315,6 +316,42 @@ class GlobalRegistry {
       endsWith(email, '@test.com') ||
       endsWith(email, '@test.cru.org')
     )
+  }
+
+  async resolveAccountNumberCollision(profile: OktaUserProfile): Promise<void> {
+    const employeeId = profile.usEmployeeId
+    if (
+      !employeeId ||
+      this.isProbablyTestAccount(profile.login) ||
+      !hasCruDomain(profile.login) ||
+      profile.orca === false
+    ) {
+      return
+    }
+
+    const fields = 'account_number,hcm_person_number,email_address'
+    const [byAccountNumber, byHcmPersonNumber] = await Promise.all([
+      this.findConflictCandidates({ account_number: employeeId }, fields),
+      this.findConflictCandidates({ hcm_person_number: employeeId }, fields)
+    ])
+
+    const candidatesById = new Map<string, Record<string, unknown>>()
+    for (const entity of [...byAccountNumber, ...byHcmPersonNumber]) {
+      const personId = get(entity, 'person.id') as string | undefined
+      if (personId) {
+        candidatesById.set(personId, entity)
+      }
+    }
+
+    for (const entity of candidatesById.values()) {
+      if (this.isAccountNumberConflict(entity, profile)) {
+        // GR clear is required (runs before the new entity is posted); a failure
+        // propagates because the subsequent post would collide anyway.
+        await this.releaseAccountNumber(entity)
+        // Okta clear is best-effort (logged, never blocks onboarding).
+        await this.clearStaleOktaEmployeeId(entity)
+      }
+    }
   }
 }
 

--- a/src/models/global-registry.ts
+++ b/src/models/global-registry.ts
@@ -198,6 +198,37 @@ class GlobalRegistry {
     await this.client.Entity.delete(relationshipEntityId)
   }
 
+  isFieldNotDefinedError(error: unknown): boolean {
+    const err = error as { statusCode?: number; error?: unknown; message?: string }
+    if (err?.statusCode !== 400) {
+      return false
+    }
+    const haystack = `${JSON.stringify(err.error ?? '')} ${err.message ?? ''}`
+    return haystack.includes("can't find entity type named")
+  }
+
+  async findConflictCandidates(
+    identifierFilter: Record<string, string>,
+    fields: string
+  ): Promise<Array<Record<string, unknown>>> {
+    try {
+      const result = await this.client.Entity.get({
+        entity_type: PERSON_ENTITY_TYPE,
+        filters: { owned_by: THE_KEY_SYSYEM, ...identifierFilter },
+        fields
+      })
+      return result.entities ?? []
+    } catch (error) {
+      // During the PSHR->HCM transition a filter field may not be defined on the person
+      // type in a given environment; GR returns a 400 in that case. Treat that single
+      // field's query as "no candidates" and let the other query proceed.
+      if (this.isFieldNotDefinedError(error)) {
+        return []
+      }
+      throw error
+    }
+  }
+
   isProbablyTestAccount(email: string | undefined): boolean {
     if (!email || typeof email !== 'string') {
       return true

--- a/src/models/global-registry.ts
+++ b/src/models/global-registry.ts
@@ -229,6 +229,34 @@ class GlobalRegistry {
     }
   }
 
+  emailAddresses(entity: Record<string, unknown>): string[] {
+    const emailAddress = get(entity, 'person.email_address')
+    const list = Array.isArray(emailAddress) ? emailAddress : [emailAddress]
+    return list
+      .map((item) => get(item, 'email'))
+      .filter((email): email is string => typeof email === 'string')
+  }
+
+  isAccountNumberConflict(entity: Record<string, unknown>, profile: OktaUserProfile): boolean {
+    const accountNumber = get(entity, 'person.account_number')
+    const hcmPersonNumber = get(entity, 'person.hcm_person_number')
+    const clientIntegrationId = get(entity, 'person.client_integration_id')
+
+    // Authoritative match: actually holds this employee number in either identifier field.
+    const numberMatches =
+      equalsIgnoreCase(accountNumber, profile.usEmployeeId) ||
+      equalsIgnoreCase(hcmPersonNumber, profile.usEmployeeId)
+    if (!numberMatches) {
+      return false
+    }
+    // Never the account currently being saved.
+    if (equalsIgnoreCase(clientIntegrationId, profile.theKeyGuid)) {
+      return false
+    }
+    // A different account: none of its emails equal the saving Cru login.
+    return !this.emailAddresses(entity).some((email) => equalsIgnoreCase(email, profile.login))
+  }
+
   isProbablyTestAccount(email: string | undefined): boolean {
     if (!email || typeof email !== 'string') {
       return true

--- a/src/types/global-registry-nodejs-client.d.ts
+++ b/src/types/global-registry-nodejs-client.d.ts
@@ -7,6 +7,7 @@ declare module 'global-registry-nodejs-client' {
   interface EntityGetOptions {
     entity_type: string
     filters: Record<string, string | undefined>
+    fields?: string
   }
 
   interface EntityPostOptions {
@@ -23,6 +24,11 @@ declare module 'global-registry-nodejs-client' {
   interface EntityClient {
     get(options: EntityGetOptions): Promise<EntityResponse>
     post(entity: Record<string, unknown>, options?: EntityPostOptions): Promise<EntityResponse>
+    put(
+      id: string,
+      content: Record<string, unknown>,
+      options?: EntityPostOptions
+    ): Promise<EntityResponse>
     delete(entityId: string): Promise<void>
   }
 

--- a/src/types/okta.ts
+++ b/src/types/okta.ts
@@ -12,6 +12,7 @@ export interface OktaUserProfile extends UserProfile {
   login: string
   firstName: string
   lastName: string
+  orca?: boolean
   email?: string
   usDesignationNumber?: string
   usEmployeeId?: string

--- a/tests/config/domains.test.ts
+++ b/tests/config/domains.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { hasCruDomain } from '@/config/domains.js'
+
+describe('hasCruDomain', () => {
+  it('returns true for Google-managed Cru domains (case-insensitive)', () => {
+    expect(hasCruDomain('jon.watson@cru.org')).toBe(true)
+    expect(hasCruDomain('someone@familylife.com')).toBe(true)
+    expect(hasCruDomain('SOMEONE@CRU.ORG')).toBe(true)
+  })
+
+  it('returns false for non-Cru domains', () => {
+    expect(hasCruDomain('person@gmail.com')).toBe(false)
+    expect(hasCruDomain('person@example.com')).toBe(false)
+  })
+
+  it('returns false for malformed input', () => {
+    expect(hasCruDomain('not-an-email')).toBe(false)
+    expect(hasCruDomain('')).toBe(false)
+  })
+})

--- a/tests/handlers/sns/user-account-update-profile.test.ts
+++ b/tests/handlers/sns/user-account-update-profile.test.ts
@@ -31,7 +31,10 @@ describe('user.account.update_profile SNS message', () => {
 
   it('should update user if login/email has changed', async () => {
     await handler(updateProfileEvent as any)
-    expect(GlobalRegistry).toHaveBeenCalledWith('secret', 'https://example.com')
+    expect(GlobalRegistry).toHaveBeenCalledWith('secret', 'https://example.com', expect.objectContaining({
+      userApi: expect.any(Object),
+      groupApi: expect.any(Object)
+    }))
     expect(mockGetUser).toHaveBeenCalledWith({ userId: '00uo48gsq4ujEWoXJ0h7' })
     expect(profile.email).toEqual(profile.login)
     expect(mockCreateOrUpdateProfile).not.toHaveBeenCalled()

--- a/tests/mocks/global-registry-nodejs-client.ts
+++ b/tests/mocks/global-registry-nodejs-client.ts
@@ -3,11 +3,13 @@ import { vi } from 'vitest'
 export const mockEntityGET = vi.fn()
 export const mockEntityDELETE = vi.fn()
 export const mockEntityPOST = vi.fn()
+export const mockEntityPUT = vi.fn()
 
 export const GRClient = vi.fn().mockImplementation(() => ({
   Entity: {
     get: mockEntityGET,
     delete: mockEntityDELETE,
-    post: mockEntityPOST
+    post: mockEntityPOST,
+    put: mockEntityPUT
   }
 }))

--- a/tests/mocks/okta-sdk-nodejs.ts
+++ b/tests/mocks/okta-sdk-nodejs.ts
@@ -18,6 +18,7 @@ export const setUsers = (users: MockUser[] = []) => {
 
 export const mockGetUser = vi.fn()
 export const mockUpdateUser = vi.fn()
+export const mockListUsers = vi.fn()
 export const mockUnassignUserFromGroup = vi.fn()
 export const mockListGroupUsers = vi.fn(() => ({
   each: (fn: (user: MockUser) => boolean | void) => forEach(values.users, fn)
@@ -26,7 +27,8 @@ export const mockListGroupUsers = vi.fn(() => ({
 export const Client = vi.fn().mockImplementation(() => ({
   userApi: {
     getUser: mockGetUser,
-    updateUser: mockUpdateUser
+    updateUser: mockUpdateUser,
+    listUsers: mockListUsers
   },
   groupApi: {
     listGroupUsers: mockListGroupUsers,

--- a/tests/models/global-registry.test.ts
+++ b/tests/models/global-registry.test.ts
@@ -229,6 +229,7 @@ describe('GlobalRegistry', () => {
       }
       vi.spyOn(globalRegistry, 'buildPersonEntity').mockResolvedValue({ client_integration_id: profile.theKeyGuid })
       vi.spyOn(globalRegistry, 'deleteDesignationRelationshipIfNecessary').mockResolvedValue(undefined)
+      vi.spyOn(globalRegistry, 'resolveAccountNumberCollision').mockResolvedValue(undefined)
     })
 
     it('should return true if profile was updated', async () => {
@@ -279,6 +280,20 @@ describe('GlobalRegistry', () => {
         }
       })
       expect(await globalRegistry.createOrUpdateProfile(profile)).toBeFalsy()
+    })
+
+    it('resolves account_number collisions before posting the entity', async () => {
+      const order: string[] = []
+      vi.spyOn(globalRegistry, 'resolveAccountNumberCollision').mockImplementation(async () => {
+        order.push('resolve')
+      })
+      mockEntityPOST.mockImplementation(async () => {
+        order.push('post')
+        return { entity: { person: { id: uuid() } } }
+      })
+      await globalRegistry.createOrUpdateProfile(profile)
+      expect(globalRegistry.resolveAccountNumberCollision).toHaveBeenCalledWith(profile)
+      expect(order).toEqual(['resolve', 'post'])
     })
   })
 

--- a/tests/models/global-registry.test.ts
+++ b/tests/models/global-registry.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import GlobalRegistry, { PERSON_DESIGNATION_ENTITY_TYPE } from '@/models/global-registry.js'
-import { GRClient, mockEntityGET, mockEntityDELETE, mockEntityPOST } from 'global-registry-nodejs-client'
+import { GRClient, mockEntityGET, mockEntityDELETE, mockEntityPOST, mockEntityPUT } from 'global-registry-nodejs-client'
 import { v4 as uuid } from 'uuid'
 
 vi.mock('global-registry-nodejs-client', async () => {
-  const { mockEntityGET, mockEntityDELETE, mockEntityPOST, GRClient } = await import('../mocks/global-registry-nodejs-client.js')
-  return { GRClient, mockEntityGET, mockEntityDELETE, mockEntityPOST }
+  const { mockEntityGET, mockEntityDELETE, mockEntityPOST, mockEntityPUT, GRClient } = await import('../mocks/global-registry-nodejs-client.js')
+  return { GRClient, mockEntityGET, mockEntityDELETE, mockEntityPOST, mockEntityPUT }
 })
 
 describe('GlobalRegistry', () => {
@@ -394,6 +394,17 @@ describe('GlobalRegistry', () => {
         }
       }
       expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(false)
+    })
+  })
+
+  describe('releaseAccountNumber( entity )', () => {
+    it('clears account_number and hcm_person_number by person id via PUT', async () => {
+      mockEntityPUT.mockResolvedValue({})
+      await globalRegistry.releaseAccountNumber({ person: { id: 'person-123' } })
+      expect(mockEntityPUT).toHaveBeenCalledWith('person-123', {
+        account_number: null,
+        hcm_person_number: null
+      })
     })
   })
 

--- a/tests/models/global-registry.test.ts
+++ b/tests/models/global-registry.test.ts
@@ -20,6 +20,12 @@ describe('GlobalRegistry', () => {
       expect(globalRegistry.client).toBeDefined()
       expect(GRClient).toHaveBeenCalledWith({ accessToken: 'token', baseUrl: 'https://example.com' })
     })
+
+    it('accepts an optional Okta client', () => {
+      const okta = { userApi: {} } as any
+      const gr = new GlobalRegistry('token', 'https://example.com', okta)
+      expect(gr).toBeInstanceOf(GlobalRegistry)
+    })
   })
 
   describe('isProbablyTestAccount( email )', () => {

--- a/tests/models/global-registry.test.ts
+++ b/tests/models/global-registry.test.ts
@@ -453,6 +453,134 @@ describe('GlobalRegistry', () => {
     })
   })
 
+  describe('resolveAccountNumberCollision( profile )', () => {
+    let okta: any
+    let updateUser: ReturnType<typeof vi.fn>
+    let listUsers: ReturnType<typeof vi.fn>
+    let gr: GlobalRegistry
+
+    const conflictEntity = (overrides: Record<string, unknown> = {}) => ({
+      person: {
+        id: 'stale-person-id',
+        account_number: '12345678',
+        hcm_person_number: '12345678',
+        client_integration_id: 'STALE-GUID',
+        email_address: { email: 'jon@gmail.com' },
+        ...overrides
+      }
+    })
+
+    const staffProfile = (overrides: Record<string, unknown> = {}) =>
+      ({
+        theKeyGuid: 'NEW-GUID',
+        login: 'jon.watson@cru.org',
+        usEmployeeId: '12345678',
+        ...overrides
+      }) as any
+
+    beforeEach(() => {
+      updateUser = vi.fn().mockResolvedValue(undefined)
+      listUsers = vi.fn().mockResolvedValue({
+        each: (fn: (u: any) => void) =>
+          [{ id: 'okta-stale-id', profile: { theKeyGuid: 'STALE-GUID', usEmployeeId: '12345678' } }].forEach(fn)
+      })
+      okta = { userApi: { listUsers, updateUser } }
+      gr = new GlobalRegistry('token', 'https://example.com', okta)
+      mockEntityPUT.mockResolvedValue({})
+    })
+
+    it.each([
+      ['no usEmployeeId', staffProfile({ usEmployeeId: undefined })],
+      ['test account', staffProfile({ login: 'test.jon@cru.org' })],
+      ['non-Cru email', staffProfile({ login: 'jon@gmail.com' })],
+      ['orca === false', staffProfile({ orca: false })]
+    ])('skips entirely when gated out: %s', async (_label, profile) => {
+      await gr.resolveAccountNumberCollision(profile)
+      expect(mockEntityGET).not.toHaveBeenCalled()
+      expect(mockEntityPUT).not.toHaveBeenCalled()
+      expect(updateUser).not.toHaveBeenCalled()
+    })
+
+    it('proceeds when orca is undefined (treated as onboarded)', async () => {
+      mockEntityGET.mockResolvedValue({ entities: [] })
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityGET).toHaveBeenCalledTimes(2)
+    })
+
+    it('queries both identifier fields', async () => {
+      mockEntityGET.mockResolvedValue({ entities: [] })
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityGET).toHaveBeenCalledWith({
+        entity_type: 'person',
+        filters: { owned_by: 'the_key', account_number: '12345678' },
+        fields: 'account_number,hcm_person_number,email_address'
+      })
+      expect(mockEntityGET).toHaveBeenCalledWith({
+        entity_type: 'person',
+        filters: { owned_by: 'the_key', hcm_person_number: '12345678' },
+        fields: 'account_number,hcm_person_number,email_address'
+      })
+    })
+
+    it('does nothing when there is no conflict', async () => {
+      mockEntityGET.mockResolvedValue({ entities: [] })
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityPUT).not.toHaveBeenCalled()
+      expect(updateUser).not.toHaveBeenCalled()
+    })
+
+    it('clears GR and Okta for a single conflict', async () => {
+      mockEntityGET.mockResolvedValue({ entities: [conflictEntity()] })
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityPUT).toHaveBeenCalledWith('stale-person-id', {
+        account_number: null,
+        hcm_person_number: null
+      })
+      expect(listUsers).toHaveBeenCalledWith({ search: 'profile.theKeyGuid eq "STALE-GUID"' })
+      expect(updateUser).toHaveBeenCalledTimes(1)
+    })
+
+    it('de-duplicates an entity returned by both queries (one PUT)', async () => {
+      mockEntityGET.mockResolvedValue({ entities: [conflictEntity()] })
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityPUT).toHaveBeenCalledTimes(1)
+    })
+
+    it('resolves an HCM-only conflict (account_number absent)', async () => {
+      const hcmOnly = conflictEntity({ account_number: undefined })
+      mockEntityGET
+        .mockResolvedValueOnce({ entities: [] })
+        .mockResolvedValueOnce({ entities: [hcmOnly] })
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityPUT).toHaveBeenCalledWith('stale-person-id', {
+        account_number: null,
+        hcm_person_number: null
+      })
+    })
+
+    it('continues when one field query 400s (field not defined)', async () => {
+      mockEntityGET
+        .mockResolvedValueOnce({ entities: [conflictEntity()] })
+        .mockRejectedValueOnce({
+          statusCode: 400,
+          error: { error: "can't find entity type named 'hcm_person_number' that is a child of \"person\"" }
+        })
+      await gr.resolveAccountNumberCollision(staffProfile())
+      expect(mockEntityPUT).toHaveBeenCalledTimes(1)
+    })
+
+    it('propagates a non-field GR error from a query', async () => {
+      mockEntityGET.mockRejectedValue({ statusCode: 500, error: 'boom' })
+      await expect(gr.resolveAccountNumberCollision(staffProfile())).rejects.toBeDefined()
+    })
+
+    it('propagates a GR PUT failure (required step)', async () => {
+      mockEntityGET.mockResolvedValue({ entities: [conflictEntity()] })
+      mockEntityPUT.mockRejectedValue(new Error('put failed'))
+      await expect(gr.resolveAccountNumberCollision(staffProfile())).rejects.toThrow('put failed')
+    })
+  })
+
   describe('deleteProfile( profile )', () => {
     it('should remove person and designation fro GR', async () => {
       const profile = { theKeyGuid: uuid(), thekeyGrPersonId: uuid(), grMasterPersonId: uuid() } as any

--- a/tests/models/global-registry.test.ts
+++ b/tests/models/global-registry.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import GlobalRegistry, { PERSON_DESIGNATION_ENTITY_TYPE } from '@/models/global-registry.js'
 import { GRClient, mockEntityGET, mockEntityDELETE, mockEntityPOST, mockEntityPUT } from 'global-registry-nodejs-client'
 import { v4 as uuid } from 'uuid'
+import rollbar from '@/config/rollbar.js'
 
 vi.mock('global-registry-nodejs-client', async () => {
   const { mockEntityGET, mockEntityDELETE, mockEntityPOST, mockEntityPUT, GRClient } = await import('../mocks/global-registry-nodejs-client.js')
   return { GRClient, mockEntityGET, mockEntityDELETE, mockEntityPOST, mockEntityPUT }
 })
+
+vi.mock('@/config/rollbar.js')
 
 describe('GlobalRegistry', () => {
   let globalRegistry: GlobalRegistry
@@ -405,6 +408,48 @@ describe('GlobalRegistry', () => {
         account_number: null,
         hcm_person_number: null
       })
+    })
+  })
+
+  describe('clearStaleOktaEmployeeId( entity )', () => {
+    const entity = { person: { client_integration_id: 'STALE-GUID' } }
+
+    it('does nothing when no Okta client is configured', async () => {
+      const gr = new GlobalRegistry('token', 'https://example.com')
+      await gr.clearStaleOktaEmployeeId(entity)
+      // No throw, nothing to assert beyond completion.
+    })
+
+    it('nulls usEmployeeId on the matched user and updates Okta', async () => {
+      const staleUser = { id: 'okta-stale-id', profile: { theKeyGuid: 'STALE-GUID', usEmployeeId: '12345678' } }
+      const updateUser = vi.fn().mockResolvedValue(undefined)
+      const listUsers = vi.fn().mockResolvedValue({
+        each: (fn: (u: any) => void) => [staleUser].forEach(fn)
+      })
+      const okta = { userApi: { listUsers, updateUser } } as any
+      const gr = new GlobalRegistry('token', 'https://example.com', okta)
+
+      await gr.clearStaleOktaEmployeeId(entity)
+
+      expect(listUsers).toHaveBeenCalledWith({ search: 'profile.theKeyGuid eq "STALE-GUID"' })
+      expect(staleUser.profile.usEmployeeId).toBeNull()
+      expect(updateUser).toHaveBeenCalledWith({ userId: 'okta-stale-id', user: staleUser })
+    })
+
+    it('logs to Rollbar and does not throw when Okta fails', async () => {
+      const listUsers = vi.fn().mockRejectedValue(new Error('okta down'))
+      const okta = { userApi: { listUsers, updateUser: vi.fn() } } as any
+      const gr = new GlobalRegistry('token', 'https://example.com', okta)
+
+      await expect(gr.clearStaleOktaEmployeeId(entity)).resolves.toBeUndefined()
+      expect(rollbar.error).toHaveBeenCalled()
+    })
+
+    it('does nothing when the entity has no client_integration_id', async () => {
+      const okta = { userApi: { listUsers: vi.fn(), updateUser: vi.fn() } } as any
+      const gr = new GlobalRegistry('token', 'https://example.com', okta)
+      await gr.clearStaleOktaEmployeeId({ person: {} })
+      expect(okta.userApi.listUsers).not.toHaveBeenCalled()
     })
   })
 

--- a/tests/models/global-registry.test.ts
+++ b/tests/models/global-registry.test.ts
@@ -279,6 +279,44 @@ describe('GlobalRegistry', () => {
     })
   })
 
+  describe('findConflictCandidates( filter, fields )', () => {
+    it('returns entities for a matching filter', async () => {
+      const entities = [{ person: { id: 'p1' } }]
+      mockEntityGET.mockResolvedValue({ entities })
+      const result = await globalRegistry.findConflictCandidates(
+        { account_number: '12345678' },
+        'account_number,hcm_person_number,email_address'
+      )
+      expect(result).toEqual(entities)
+      expect(mockEntityGET).toHaveBeenCalledWith({
+        entity_type: 'person',
+        filters: { owned_by: 'the_key', account_number: '12345678' },
+        fields: 'account_number,hcm_person_number,email_address'
+      })
+    })
+
+    it('returns [] when GR has no entities key', async () => {
+      mockEntityGET.mockResolvedValue({})
+      expect(await globalRegistry.findConflictCandidates({ hcm_person_number: 'x' }, 'f')).toEqual([])
+    })
+
+    it('treats a "field not defined" 400 as empty', async () => {
+      mockEntityGET.mockRejectedValue({
+        statusCode: 400,
+        error: { error: "can't find entity type named 'hcm_person_number' that is a child of \"person\"" }
+      })
+      expect(await globalRegistry.findConflictCandidates({ hcm_person_number: 'x' }, 'f')).toEqual([])
+    })
+
+    it('re-throws any other error', async () => {
+      mockEntityGET.mockRejectedValue({ statusCode: 500, error: 'boom' })
+      await expect(globalRegistry.findConflictCandidates({ account_number: 'x' }, 'f')).rejects.toEqual({
+        statusCode: 500,
+        error: 'boom'
+      })
+    })
+  })
+
   describe('deleteProfile( profile )', () => {
     it('should remove person and designation fro GR', async () => {
       const profile = { theKeyGuid: uuid(), thekeyGrPersonId: uuid(), grMasterPersonId: uuid() } as any

--- a/tests/models/global-registry.test.ts
+++ b/tests/models/global-registry.test.ts
@@ -317,6 +317,86 @@ describe('GlobalRegistry', () => {
     })
   })
 
+  describe('isAccountNumberConflict( entity, profile )', () => {
+    const profile = {
+      theKeyGuid: 'NEW-GUID',
+      login: 'jon.watson@cru.org',
+      usEmployeeId: '12345678'
+    } as any
+
+    it('true: account_number matches, different email, different guid', () => {
+      const entity = {
+        person: {
+          id: 'p1',
+          account_number: '12345678',
+          client_integration_id: 'STALE-GUID',
+          email_address: { email: 'jon@gmail.com' }
+        }
+      }
+      expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(true)
+    })
+
+    it('true: matches on hcm_person_number only', () => {
+      const entity = {
+        person: {
+          id: 'p1',
+          hcm_person_number: '12345678',
+          client_integration_id: 'STALE-GUID',
+          email_address: { email: 'jon@gmail.com' }
+        }
+      }
+      expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(true)
+    })
+
+    it('true: email_address is an array with no matching email', () => {
+      const entity = {
+        person: {
+          id: 'p1',
+          account_number: '12345678',
+          client_integration_id: 'STALE-GUID',
+          email_address: [{ email: 'jon@gmail.com' }, { email: 'jon@yahoo.com' }]
+        }
+      }
+      expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(true)
+    })
+
+    it('false: number does not actually match (loose filter guard)', () => {
+      const entity = {
+        person: {
+          id: 'p1',
+          account_number: '99999999',
+          client_integration_id: 'STALE-GUID',
+          email_address: { email: 'jon@gmail.com' }
+        }
+      }
+      expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(false)
+    })
+
+    it('false: same account being saved (client_integration_id matches theKeyGuid)', () => {
+      const entity = {
+        person: {
+          id: 'p1',
+          account_number: '12345678',
+          client_integration_id: 'NEW-GUID',
+          email_address: { email: 'jon.watson@cru.org' }
+        }
+      }
+      expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(false)
+    })
+
+    it('false: one of the emails matches the saving login', () => {
+      const entity = {
+        person: {
+          id: 'p1',
+          account_number: '12345678',
+          client_integration_id: 'STALE-GUID',
+          email_address: [{ email: 'old@gmail.com' }, { email: 'jon.watson@cru.org' }]
+        }
+      }
+      expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(false)
+    })
+  })
+
   describe('deleteProfile( profile )', () => {
     it('should remove person and designation fro GR', async () => {
       const profile = { theKeyGuid: uuid(), thekeyGrPersonId: uuid(), grMasterPersonId: uuid() } as any

--- a/tests/models/global-registry.test.ts
+++ b/tests/models/global-registry.test.ts
@@ -561,6 +561,31 @@ describe('GlobalRegistry', () => {
       expect(mockEntityPUT).toHaveBeenCalledTimes(1)
     })
 
+    it('clears each of multiple distinct conflicts', async () => {
+      const entityA = conflictEntity({
+        id: 'stale-A',
+        client_integration_id: 'GUID-A',
+        email_address: { email: 'a@gmail.com' }
+      })
+      const entityB = conflictEntity({
+        id: 'stale-B',
+        client_integration_id: 'GUID-B',
+        email_address: { email: 'b@gmail.com' }
+      })
+      mockEntityGET
+        .mockResolvedValueOnce({ entities: [entityA] }) // account_number query
+        .mockResolvedValueOnce({ entities: [entityB] }) // hcm_person_number query
+
+      await gr.resolveAccountNumberCollision(staffProfile())
+
+      expect(mockEntityPUT).toHaveBeenCalledTimes(2)
+      expect(mockEntityPUT).toHaveBeenCalledWith('stale-A', { account_number: null, hcm_person_number: null })
+      expect(mockEntityPUT).toHaveBeenCalledWith('stale-B', { account_number: null, hcm_person_number: null })
+      expect(updateUser).toHaveBeenCalledTimes(2)
+      expect(listUsers).toHaveBeenCalledWith({ search: 'profile.theKeyGuid eq "GUID-A"' })
+      expect(listUsers).toHaveBeenCalledWith({ search: 'profile.theKeyGuid eq "GUID-B"' })
+    })
+
     it('resolves an HCM-only conflict (account_number absent)', async () => {
       const hcmOnly = conflictEntity({ account_number: undefined })
       mockEntityGET

--- a/tests/models/global-registry.test.ts
+++ b/tests/models/global-registry.test.ts
@@ -303,13 +303,13 @@ describe('GlobalRegistry', () => {
       mockEntityGET.mockResolvedValue({ entities })
       const result = await globalRegistry.findConflictCandidates(
         { account_number: '12345678' },
-        'account_number,hcm_person_number,email_address'
+        'account_number,hcm_person_number'
       )
       expect(result).toEqual(entities)
       expect(mockEntityGET).toHaveBeenCalledWith({
         entity_type: 'person',
         filters: { owned_by: 'the_key', account_number: '12345678' },
-        fields: 'account_number,hcm_person_number,email_address'
+        fields: 'account_number,hcm_person_number'
       })
     })
 
@@ -342,13 +342,12 @@ describe('GlobalRegistry', () => {
       usEmployeeId: '12345678'
     } as any
 
-    it('true: account_number matches, different email, different guid', () => {
+    it('true: account_number matches, different guid', () => {
       const entity = {
         person: {
           id: 'p1',
           account_number: '12345678',
-          client_integration_id: 'STALE-GUID',
-          email_address: { email: 'jon@gmail.com' }
+          client_integration_id: 'STALE-GUID'
         }
       }
       expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(true)
@@ -359,32 +358,30 @@ describe('GlobalRegistry', () => {
         person: {
           id: 'p1',
           hcm_person_number: '12345678',
-          client_integration_id: 'STALE-GUID',
-          email_address: { email: 'jon@gmail.com' }
+          client_integration_id: 'STALE-GUID'
         }
       }
       expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(true)
     })
 
-    it('true: email_address is an array with no matching email', () => {
+    it('true: email is irrelevant — a conflict even if an email matches the saving login', () => {
       const entity = {
         person: {
           id: 'p1',
           account_number: '12345678',
           client_integration_id: 'STALE-GUID',
-          email_address: [{ email: 'jon@gmail.com' }, { email: 'jon@yahoo.com' }]
+          email_address: [{ email: 'old@gmail.com' }, { email: 'jon.watson@cru.org' }]
         }
       }
       expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(true)
     })
 
-    it('false: number does not actually match (loose filter guard)', () => {
+    it('false: neither identifier field matches the employee number', () => {
       const entity = {
         person: {
           id: 'p1',
           account_number: '99999999',
-          client_integration_id: 'STALE-GUID',
-          email_address: { email: 'jon@gmail.com' }
+          client_integration_id: 'STALE-GUID'
         }
       }
       expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(false)
@@ -395,20 +392,7 @@ describe('GlobalRegistry', () => {
         person: {
           id: 'p1',
           account_number: '12345678',
-          client_integration_id: 'NEW-GUID',
-          email_address: { email: 'jon.watson@cru.org' }
-        }
-      }
-      expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(false)
-    })
-
-    it('false: one of the emails matches the saving login', () => {
-      const entity = {
-        person: {
-          id: 'p1',
-          account_number: '12345678',
-          client_integration_id: 'STALE-GUID',
-          email_address: [{ email: 'old@gmail.com' }, { email: 'jon.watson@cru.org' }]
+          client_integration_id: 'NEW-GUID'
         }
       }
       expect(globalRegistry.isAccountNumberConflict(entity, profile)).toBe(false)
@@ -528,12 +512,12 @@ describe('GlobalRegistry', () => {
       expect(mockEntityGET).toHaveBeenCalledWith({
         entity_type: 'person',
         filters: { owned_by: 'the_key', account_number: '12345678' },
-        fields: 'account_number,hcm_person_number,email_address'
+        fields: 'account_number,hcm_person_number'
       })
       expect(mockEntityGET).toHaveBeenCalledWith({
         entity_type: 'person',
         filters: { owned_by: 'the_key', hcm_person_number: '12345678' },
-        fields: 'account_number,hcm_person_number,email_address'
+        fields: 'account_number,hcm_person_number'
       })
     })
 


### PR DESCRIPTION
## Summary

Adds collision resolution to okta-hooks so a returning staff member (who gets a brand-new Cru-email Okta account) can be saved to Global Registry even though their old personal account already holds the same employee number.

GR enforces a uniqueness constraint on both `account_number` and `hcm_person_number` for `the_key`-owned person entities. Before saving the new entity, `GlobalRegistry.createOrUpdateProfile` now:

1. **Gates** to staff accounts only: `usEmployeeId` present, not a test account, Cru-domain email (`hasCruDomain`), and `orca !== false`.
2. **Looks up both identifier fields** (`account_number` and `hcm_person_number`) among `the_key` persons — transition-resilient for the PSHR → Oracle HCM migration (a "field not defined" 400 on one field is treated as empty; other errors propagate). Results are unioned and de-duplicated by `person.id`.
3. **Selects true conflicts** — identifier-only: the candidate actually holds the employee number (in `account_number` or `hcm_person_number`) and is a different account (`client_integration_id` ≠ the saving `theKeyGuid`). GR forbids two `the_key` entities sharing the number, so any other holder is a collision; email is not part of the test.
4. For each conflict: **clears `account_number` + `hcm_person_number`** on the stale `the_key` entity via `Entity.put` (required — failure propagates), then **clears `usEmployeeId`** on the stale Okta account (located by `theKeyGuid`) — best-effort, logged to Rollbar on failure so onboarding isn't blocked.

The three SNS handlers now pass their Okta client into `GlobalRegistry`.

All four GR behavioral assumptions (filterability, partial-PUT clear semantics, response shape, `the_key`-only constraint) were verified against stage and the Global Registry source. Design spec and implementation plan are under `docs/superpowers/`.

## Changes

- `src/config/domains.ts` (new) — `hasCruDomain` + managed-domain list (ported from us-onboarding; also duplicated in celigo).
- `src/models/global-registry.ts` — optional Okta client; `resolveAccountNumberCollision` + helpers; called first in `createOrUpdateProfile`.
- `src/types/okta.ts` — `orca?: boolean`.
- `src/types/global-registry-nodejs-client.d.ts` — `put` + `fields` on the client type.
- `src/handlers/sns/{user-lifecycle-create,user-lifecycle-status-change,user-account-update-profile}.ts` — pass the Okta client.
- Tests + mocks updated throughout.

## Test Plan

- [x] `npm run test` — 102 passing (15 files); `global-registry.ts` 100% stmts
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — 8 handlers built
- [ ] Verify in stage against a real returning-staff scenario